### PR TITLE
Agent automation: scheduled backlog + @claude mention

### DIFF
--- a/.github/scripts/pick-model.sh
+++ b/.github/scripts/pick-model.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Pick the Claude model for an issue from its labels.
+#
+# Matrix (see AGENTS.md → Model selection):
+#   P1                       -> Opus   (critical; often lifecycle / concurrency / architecture)
+#   P3 or "good first issue" -> Haiku  (trivial / mechanical)
+#   everything else          -> Sonnet (the default workhorse)
+#
+# Usage: pick-model.sh <issue-number>
+# Prints `model=<id>` on stdout (append to $GITHUB_OUTPUT); diagnostics on stderr.
+set -euo pipefail
+
+issue="${1:?usage: pick-model.sh <issue-number>}"
+
+labels="$(gh issue view "$issue" --json labels --jq '[.labels[].name] | join(",")')"
+
+model="claude-sonnet-4-6" # default
+case ",$labels," in
+  *,P1,*)                         model="claude-opus-4-8" ;;
+  *,P3,* | *,"good first issue",*) model="claude-haiku-4-5" ;;
+esac
+
+echo "issue #$issue labels=[$labels] -> $model" >&2
+echo "model=$model"

--- a/.github/scripts/pick-next-issue.sh
+++ b/.github/scripts/pick-next-issue.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Emit the next open issue to work on, in priority order (P1 > P2 > P3).
+#
+# Skips: issues already assigned to someone, issues carrying the
+# `agent:in-progress` label (claimed by a previous run), and the tracking
+# issue (title starting "Tracking:"). Within a priority, lowest number first.
+#
+# Prints `number=<n>` (empty if nothing eligible) on stdout; append to
+# $GITHUB_OUTPUT. Diagnostics on stderr.
+set -euo pipefail
+
+issues="$(gh issue list --state open --limit 100 \
+  --json number,title,labels,assignees)"
+
+pick() {
+  local prio="$1"
+  printf '%s' "$issues" | jq -r --arg prio "$prio" '
+    map(select(.assignees | length == 0))
+    | map(select([.labels[].name] | index("agent:in-progress") | not))
+    | map(select(.title | test("^Tracking:") | not))
+    | map(select([.labels[].name] | index($prio)))
+    | sort_by(.number)
+    | (.[0].number // empty)'
+}
+
+number=""
+for prio in P1 P2 P3; do
+  number="$(pick "$prio")"
+  if [ -n "$number" ]; then
+    echo "next eligible issue: #$number ($prio)" >&2
+    break
+  fi
+done
+
+[ -z "$number" ] && echo "no eligible issue found" >&2
+echo "number=$number"

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -1,0 +1,45 @@
+name: Claude (@mention)
+
+# Event-driven: someone writes "@claude ..." in an issue or PR comment, or an
+# issue is assigned. The model is chosen from the issue's labels (P1 -> Opus,
+# P3/good-first -> Haiku, else Sonnet). Requires the ANTHROPIC_API_KEY secret
+# (or swap for claude_code_oauth_token). See docs/AUTOMATION.md.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [assigned]
+
+# Don't run on our own bot comments or on unrelated chatter.
+jobs:
+  claude:
+    if: >-
+      github.event_name == 'issues' ||
+      contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    concurrency:
+      group: claude-mention-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pick model from issue labels
+        id: model
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          n="${{ github.event.issue.number || github.event.pull_request.number }}"
+          bash .github/scripts/pick-model.sh "$n" >> "$GITHUB_OUTPUT"
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # The action reads the @claude comment as the task automatically.
+          claude_args: "--model ${{ steps.model.outputs.model }} --max-turns 20"

--- a/.github/workflows/claude-scheduled.yml
+++ b/.github/workflows/claude-scheduled.yml
@@ -1,0 +1,81 @@
+name: Claude (scheduled backlog)
+
+# Time-driven: every 6 hours, pick the next open issue in priority order,
+# claim it, implement it on a branch, and open a DRAFT PR. Never merges,
+# never pushes to master. The model is chosen from the issue's labels.
+# Requires the ANTHROPIC_API_KEY secret. See docs/AUTOMATION.md.
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch: # allow a manual "run now" from the Actions tab
+
+concurrency:
+  group: claude-scheduled
+  cancel-in-progress: false
+
+jobs:
+  work-next-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure claim label exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create "agent:in-progress" \
+            --color "fbca04" --description "Claimed by the scheduled Claude run" \
+            2>/dev/null || true
+
+      - name: Pick next issue
+        id: next
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/pick-next-issue.sh >> "$GITHUB_OUTPUT"
+
+      - name: Pick model
+        id: model
+        if: steps.next.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/pick-model.sh "${{ steps.next.outputs.number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Claim the issue
+        if: steps.next.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh issue edit "${{ steps.next.outputs.number }}" --add-label "agent:in-progress"
+
+      - name: Implement and open a draft PR
+        if: steps.next.outputs.number != ''
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--model ${{ steps.model.outputs.model }} --max-turns 40"
+          prompt: |
+            You are working through the issue backlog of this repository,
+            unattended. Read AGENTS.md and docs/adr/ FIRST, then work only on
+            GitHub issue #${{ steps.next.outputs.number }}.
+
+            Rules (non-negotiable):
+            - Create a branch named `claude/${{ steps.next.outputs.number }}-<short-slug>`.
+              NEVER commit or push to `master`.
+            - Implement the issue. Add or update tests. Run the relevant checks
+              (`npm test`, `npm run check`, `ruff check custom_components tests`,
+              `pytest -q`) and make them pass locally before opening the PR.
+            - Open a **draft** PR against master with `gh pr create --draft`,
+              linking the issue (`Closes #${{ steps.next.outputs.number }}`) and
+              summarising what you changed and how you verified it.
+            - If the issue is ambiguous, under-specified, or you cannot verify the
+              fix, DO NOT guess. Open the draft PR with your partial work and a
+              clear "Blocked / needs decision" section, and stop.
+            - Respect the dependency order in the tracking issue (#20): if this
+              issue depends on something not yet merged, say so in the PR and keep
+              the change minimal.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,15 @@ every push. If you iterate with several pushes, open the PR as a
 **draft** until you expect CI to pass, then mark ready. Direct push to
 `master` is not the flow; open a PR.
 
+## Automation
+
+Two workflows let Claude work issues automatically, both draft-PR-only
+(see [`docs/AUTOMATION.md`](docs/AUTOMATION.md)): a **scheduled** backlog
+run every 6 h that picks the next issue by priority, and an **@claude**
+mention handler. Both choose the model from the issue's labels via
+`.github/scripts/pick-model.sh` (P1 → Opus, P3/good-first → Haiku, else
+Sonnet).
+
 ## Testing
 
 - **Card decoder**: `npm test` (vitest). The pure decoder functions are

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -1,0 +1,53 @@
+# Agent automation
+
+Two ways Claude works on this repo's issues automatically. Both open **draft
+PRs only** and never push to `master` (branch protection enforces this). The
+model is chosen per issue from its labels.
+
+## Model selection (both flows)
+
+`.github/scripts/pick-model.sh <issue>` maps labels to a model:
+
+| Label on the issue | Model |
+|---|---|
+| `P1` | `claude-opus-4-8` (critical; lifecycle / concurrency / architecture) |
+| `P3` or `good first issue` | `claude-haiku-4-5` (trivial / mechanical) |
+| anything else (`P2`, `tests`, `release`, unlabelled) | `claude-sonnet-4-6` (default) |
+
+## 1. Scheduled backlog (`claude-scheduled.yml`)
+
+Cron every 6 hours (plus a manual "Run workflow" button). Each run:
+
+1. picks the next open issue in priority order (`pick-next-issue.sh`: P1 > P2 >
+   P3, skips assigned issues, issues labelled `agent:in-progress`, and the
+   tracking issue),
+2. claims it with the `agent:in-progress` label so the next run skips it,
+3. implements it on a `claude/<n>-<slug>` branch and opens a **draft** PR.
+
+The clock only says "go" — the workflow itself figures out *which* issue via the
+labels and the tracking issue. Change the cadence by editing the `cron` line.
+
+## 2. On @claude mention (`claude-mention.yml`)
+
+Event-driven. Write `@claude ...` in an issue or PR comment (or assign an issue)
+and Claude picks up *that* issue, using the model its labels imply.
+
+## Required one-time setup (maintainer)
+
+These automations need Anthropic credentials the repo doesn't have yet:
+
+1. **Install the Claude GitHub App** on this repo (grants the action its
+   permissions): <https://github.com/apps/claude>.
+2. **Add a repository secret** `ANTHROPIC_API_KEY` (Settings → Secrets and
+   variables → Actions), or swap the workflows to
+   `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`.
+
+Until the secret exists, the workflows run but the Claude step fails — no
+changes are made. Everything else (issue picking, labelling) is harmless.
+
+## Guardrails
+
+- Draft PRs only; **merge stays manual** (you).
+- One issue per scheduled run; priority + tracking-issue order.
+- Ambiguous issue → the agent opens a draft with a "Blocked / needs decision"
+  note instead of guessing.


### PR DESCRIPTION
Adds the two automation flows from the workflow effort. Both are **draft-PR-only** and never touch `master` (branch protection enforces it). Per-issue **model selection** from labels.

## What lands
- **`.github/scripts/pick-model.sh`** — label → model: `P1`→`claude-opus-4-8`, `P3`/`good first issue`→`claude-haiku-4-5`, else `claude-sonnet-4-6`.
- **`.github/scripts/pick-next-issue.sh`** — next open issue by priority (P1>P2>P3), skipping assigned / `agent:in-progress` / the tracking issue.
- **`.github/workflows/claude-scheduled.yml`** — cron `0 */6 * * *` (+ manual dispatch): pick → claim → implement on a branch → open a draft PR.
- **`.github/workflows/claude-mention.yml`** — `@claude` in a comment or an issue assignment → work that issue.
- **`docs/AUTOMATION.md`** — how both work + the one-time maintainer setup.

## Before it can actually run (maintainer, one-time)
1. Install the **Claude GitHub App** on the repo.
2. Add repo secret **`ANTHROPIC_API_KEY`** (or switch to `CLAUDE_CODE_OAUTH_TOKEN`).

Until then the Claude step fails harmlessly; issue-picking/labelling is inert.

## Guardrails
Draft PRs only, merge stays manual; one issue per scheduled run; ambiguous issue → draft with a "Blocked / needs decision" note instead of guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)