### PR TITLE
Auth: use CLAUDE_CODE_OAUTH_TOKEN for agent workflows

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -2,8 +2,8 @@ name: Claude (@mention)
 
 # Event-driven: someone writes "@claude ..." in an issue or PR comment, or an
 # issue is assigned. The model is chosen from the issue's labels (P1 -> Opus,
-# P3/good-first -> Haiku, else Sonnet). Requires the ANTHROPIC_API_KEY secret
-# (or swap for claude_code_oauth_token). See docs/AUTOMATION.md.
+# P3/good-first -> Haiku, else Sonnet). Requires the CLAUDE_CODE_OAUTH_TOKEN
+# secret (Claude subscription). See docs/AUTOMATION.md.
 
 on:
   issue_comment:
@@ -40,6 +40,6 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The action reads the @claude comment as the task automatically.
           claude_args: "--model ${{ steps.model.outputs.model }} --max-turns 20"

--- a/.github/workflows/claude-scheduled.yml
+++ b/.github/workflows/claude-scheduled.yml
@@ -3,7 +3,8 @@ name: Claude (scheduled backlog)
 # Time-driven: every 6 hours, pick the next open issue in priority order,
 # claim it, implement it on a branch, and open a DRAFT PR. Never merges,
 # never pushes to master. The model is chosen from the issue's labels.
-# Requires the ANTHROPIC_API_KEY secret. See docs/AUTOMATION.md.
+# Requires the CLAUDE_CODE_OAUTH_TOKEN secret (Claude subscription).
+# See docs/AUTOMATION.md.
 
 on:
   schedule:
@@ -57,7 +58,7 @@ jobs:
         if: steps.next.outputs.number != ''
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model ${{ steps.model.outputs.model }} --max-turns 40"
           prompt: |
             You are working through the issue backlog of this repository,

--- a/docs/AUTOMATION.md
+++ b/docs/AUTOMATION.md
@@ -38,11 +38,15 @@ These automations need Anthropic credentials the repo doesn't have yet:
 
 1. **Install the Claude GitHub App** on this repo (grants the action its
    permissions): <https://github.com/apps/claude>.
-2. **Add a repository secret** `ANTHROPIC_API_KEY` (Settings → Secrets and
-   variables → Actions), or swap the workflows to
-   `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`.
+2. **Generate a Claude Code OAuth token** (Claude subscription):
+   `claude setup-token`.
+3. **Add it as a repository secret** `CLAUDE_CODE_OAUTH_TOKEN`
+   (`gh secret set CLAUDE_CODE_OAUTH_TOKEN`, or Settings → Secrets and
+   variables → Actions). To use an Anthropic API key instead, set
+   `ANTHROPIC_API_KEY` and switch the `with:` input back to
+   `anthropic_api_key`.
 
-Until the secret exists, the workflows run but the Claude step fails — no
+Until the secret exists, the workflows run but the Claude step fails and no
 changes are made. Everything else (issue picking, labelling) is harmless.
 
 ## Guardrails


### PR DESCRIPTION
Switches both agent workflows from `anthropic_api_key` to `claude_code_oauth_token` (Claude subscription). Docs updated with the `claude setup-token` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)