### PR TITLE
Fix agent workflows: OIDC permission + release claim on failure

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -24,6 +24,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write # claude-code-action needs OIDC for its GitHub App token
     concurrency:
       group: claude-mention-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: false

--- a/.github/workflows/claude-scheduled.yml
+++ b/.github/workflows/claude-scheduled.yml
@@ -22,6 +22,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write # claude-code-action needs OIDC for its GitHub App token
     steps:
       - uses: actions/checkout@v4
         with:
@@ -80,3 +81,11 @@ jobs:
             - Respect the dependency order in the tracking issue (#20): if this
               issue depends on something not yet merged, say so in the PR and keep
               the change minimal.
+
+      # If the Claude step failed, release the claim so the issue is retried
+      # next run instead of being stuck "in progress" forever.
+      - name: Release claim on failure
+        if: failure() && steps.next.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh issue edit "${{ steps.next.outputs.number }}" --remove-label "agent:in-progress" || true


### PR DESCRIPTION
The scheduled run reached the Claude step but failed with `Could not fetch an OIDC token`. Adds `id-token: write` to both workflows, and releases the `agent:in-progress` claim when the Claude step fails so the issue is retried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)