### PR TITLE
Security: gate @claude on author role

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -16,9 +16,14 @@ on:
 # Don't run on our own bot comments or on unrelated chatter.
 jobs:
   claude:
+    # Only the owner / collaborators can trigger this. Comment events carry
+    # secrets even from strangers, so gate the @claude path on author role
+    # (issue-assignment is already write-access-only).
     if: >-
       github.event_name == 'issues' ||
-      contains(github.event.comment.body, '@claude')
+      (contains(github.event.comment.body, '@claude') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+                github.event.comment.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Comment events carry repo secrets even for non-collaborators, so on a public repo a stranger could trigger the agent via `@claude`. Restrict the `@claude` path to `OWNER`/`MEMBER`/`COLLABORATOR`. Issue-assignment is already write-access-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)