### PR TITLE
Fix reviewer: allow bot-opened PRs to trigger it

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -43,6 +43,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The author agent opens the PR as claude[bot]; allow that bot to
+          # trigger this reviewer (default guard blocks bot-initiated runs).
+          allowed_bots: "claude"
           claude_args: "--model claude-opus-4-8 --max-turns 60 --dangerously-skip-permissions"
           prompt: |
             You are an INDEPENDENT, adversarial reviewer for pull request


### PR DESCRIPTION
The reviewer failed on the automatic path with `Workflow initiated by non-human actor: claude`: the author agent opens the PR as claude[bot], and claude-code-action's default guard blocks bot-initiated runs. Add `allowed_bots: claude` so build → review → auto-merge runs end-to-end without a human dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)