### PR TITLE
Autopilot: grind the P-backlog hands-off

### DIFF
--- a/.github/scripts/pick-next-issue.sh
+++ b/.github/scripts/pick-next-issue.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Emit the next open issue to work on, in priority order (P1 > P2 > P3).
+# Emit the next open issue for the autopilot, in priority order (P1 > P2 > P3).
 #
-# Skips: issues already assigned to someone, issues carrying the
-# `agent:in-progress` label (claimed by a previous run), and the tracking
-# issue (title starting "Tracking:"). Within a priority, lowest number first.
+# Only issues carrying a P-label are eligible (so tests/CI/tracking issues
+# without one are left for a human). Skips: the tracking issue, and issues
+# already flagged `agent:go`, `agent:in-progress` or `needs-verification`.
+# Lowest number first within a priority.
 #
-# Prints `number=<n>` (empty if nothing eligible) on stdout; append to
-# $GITHUB_OUTPUT. Diagnostics on stderr.
+# Prints `number=<n>` (empty if nothing eligible) on stdout.
 set -euo pipefail
 
 issues="$(gh issue list --state open --limit 100 \
@@ -16,7 +16,7 @@ pick() {
   local prio="$1"
   printf '%s' "$issues" | jq -r --arg prio "$prio" '
     map(select(.assignees | length == 0))
-    | map(select([.labels[].name] | index("agent:in-progress") | not))
+    | map(select([.labels[].name] | any(. == "agent:in-progress" or . == "agent:go" or . == "needs-verification") | not))
     | map(select(.title | test("^Tracking:") | not))
     | map(select([.labels[].name] | index($prio)))
     | sort_by(.number)

--- a/.github/workflows/claude-autopilot.yml
+++ b/.github/workflows/claude-autopilot.yml
@@ -1,4 +1,4 @@
-name: Claude (autopilot: grind the P-backlog)
+name: "Claude (autopilot: grind the P-backlog)"
 
 # Fully-automatic backlog clear for THIS repo (needs CI + branch protection +
 # the reviewer/auto-merge). Every 30 min: if no agent PR is currently open,

--- a/.github/workflows/claude-autopilot.yml
+++ b/.github/workflows/claude-autopilot.yml
@@ -1,0 +1,83 @@
+name: Claude (autopilot: grind the P-backlog)
+
+# Fully-automatic backlog clear for THIS repo (needs CI + branch protection +
+# the reviewer/auto-merge). Every 30 min: if no agent PR is currently open,
+# take the next open P-issue directly and open a draft PR. The reviewer then
+# auto-merges it; the next tick takes the next issue. Stops on its own when
+# the backlog is empty or an open PR is waiting (e.g. needs-verification).
+#
+# One at a time (the open-PR gate) → no same-file conflicts, no quota spike.
+# To pause: disable this workflow in the Actions tab.
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: claude-autopilot
+  cancel-in-progress: false
+
+jobs:
+  advance:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Gate: never start a second issue while an agent PR is still open.
+      - name: Check for an open agent PR
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          open="$(gh pr list --state open --json headRefName \
+            --jq '[.[] | select(.headRefName | startswith("claude/"))] | length')"
+          echo "open=$open" >> "$GITHUB_OUTPUT"
+          echo "open agent PRs: $open"
+
+      - name: Pick next issue
+        id: next
+        if: steps.gate.outputs.open == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/pick-next-issue.sh >> "$GITHUB_OUTPUT"
+
+      - name: Pick model
+        id: model
+        if: steps.gate.outputs.open == '0' && steps.next.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/pick-model.sh "${{ steps.next.outputs.number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Implement and open a draft PR
+        if: steps.gate.outputs.open == '0' && steps.next.outputs.number != ''
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--model ${{ steps.model.outputs.model }} --max-turns 40 --dangerously-skip-permissions"
+          prompt: |
+            You are working, unattended, on GitHub issue
+            #${{ steps.next.outputs.number }} of this repository. Read AGENTS.md
+            and docs/adr/ FIRST and follow them.
+
+            Rules (non-negotiable):
+            - Work on a branch `claude/${{ steps.next.outputs.number }}-<short-slug>`.
+              NEVER push to the default branch.
+            - Implement the issue, add/update tests, and make the checks pass
+              (`npm ci && npm test && npm run check`,
+              `ruff check custom_components tests && pytest -q`).
+            - You CANNOT modify `.github/workflows/`. If the fix needs that, say
+              so in the PR and stop.
+            - Open a **draft** PR (`gh pr create --draft`) against the default
+              branch, `Closes #${{ steps.next.outputs.number }}`, summarising the
+              change and how you verified it. The reviewer takes it from here.
+            - If the issue is ambiguous or you cannot verify the fix, DO NOT
+              guess: open the draft PR with partial work and a clear
+              "Blocked / needs decision" section, and stop.

--- a/docs/agent-automation.md
+++ b/docs/agent-automation.md
@@ -54,6 +54,15 @@ To force a human check on anything, add the **`needs-verification`** label to
 the issue or PR. Auto-merge respects branch protection (required checks pass
 first). Reviewer = Opus, author = Sonnet, so it is not grading its own work.
 
+## Autopilot: backlog grind (experimental, this repo)
+
+`claude-autopilot.yml` clears the P-labelled backlog hands-off: every 30 min,
+**if no agent PR is open**, it takes the next open P-issue, opens a draft PR,
+the reviewer auto-merges it, and the next tick takes the next — until the
+backlog is empty. One PR at a time (no conflicts). Skips tests/CI/tracking
+issues (no P-label) and anything `needs-verification`. Needs CI + branch
+protection + the reviewer. Pause it by disabling the workflow in Actions.
+
 ## Setup (one-time)
 
 Install the Claude GitHub App and add the repo secret


### PR DESCRIPTION
Timer worker (every 30 min): if no agent PR is open, take the next open P-issue → draft PR → reviewer auto-merges → next tick takes the next, until the backlog is empty. **One at a time** (open-PR gate) so no conflicts / no quota spike. Skips tests/CI/tracking (no P-label) and `needs-verification`. Timer (not merge-trigger) because bot actions don't reliably chain workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)