### PR TITLE
fix(release): declare HA 2024.7.0 as the minimum, not 2024.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ broken card.
 
 ## Requirements
 
-- **Home Assistant 2024.6.0 or newer.** The integration uses
-  `StaticPathConfig` / `async_register_static_paths` (2024.6) and
-  `ConfigFlowResult` (2024.4); older installs fail at import with a cryptic
-  `ImportError`.
+- **Home Assistant 2024.7.0 or newer.** The integration uses
+  `StaticPathConfig` / `async_register_static_paths` and
+  `remove_extra_js_url` (all 2024.7) plus `ConfigFlowResult` (2024.4); older
+  installs fail at import with a cryptic `ImportError`.
 
 ## Install (HACS)
 

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
   "name": "MeteoSwiss Radar",
   "content_in_root": false,
   "render_readme": true,
-  "homeassistant": "2024.6.0"
+  "homeassistant": "2024.7.0"
 }

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -94,6 +94,8 @@ def test_hacs_json_is_valid() -> None:
     assert re.fullmatch(r"\d{4}\.\d+\.\d+", hacs["homeassistant"])
     # HACS renders the README as the store page.
     assert hacs.get("render_readme") is True
-    # The declared minimum must match the newest HA API the code relies on:
-    # StaticPathConfig / async_register_static_paths landed in 2024.6.
-    assert hacs["homeassistant"] == "2024.6.0"
+    # The declared minimum must match the newest HA API the code relies on.
+    # StaticPathConfig / async_register_static_paths and remove_extra_js_url
+    # all landed in 2024.7 -- the dev-blog post announcing them is dated
+    # 2024-06-18, which is where the earlier "2024.6" claim came from.
+    assert hacs["homeassistant"] == "2024.7.0"


### PR DESCRIPTION
Closes #62.

`hacs.json` declared `2024.6.0` as the minimum Home Assistant version. The
integration imports `StaticPathConfig`, `async_register_static_paths` and
`remove_extra_js_url` at module level, and all three landed in **2024.7**. On
2024.6.x the integration therefore fails at import and never loads — while HACS,
which gates the download on that key, happily offered it.

The wrong value came from the dev-blog post announcing
`async_register_static_paths`: it is dated 2024-06-18, one release ahead of the
version the API shipped in.

## Changes

- `hacs.json`: `2024.6.0` → `2024.7.0`
- `README.md`: corrected version and API attribution, `remove_extra_js_url` added
  to the list
- `tests/test_metadata.py`: the assertion had the wrong value pinned, so the
  error was locked in by a test rather than caught by one. Now asserts `2024.7.0`
  and the comment records why 2024.6 was wrong, so it does not get "corrected"
  back.

## Why CI did not catch it

Neither hassfest nor `hacs/action` validates the declared minimum against the
APIs the code actually calls. Both stay green either way.

## Verification

- `python -m pytest -q` → 29 passed
- `python -m ruff check custom_components tests` → clean
- No `2024.6` reference left in `hacs.json`, `README.md` or `tests/`

Blocks the first release tag, so this should land before one is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)