### PR TITLE
chore(release): 0.8.0, and cover package.json in the version-sync test

### DIFF
--- a/custom_components/meteoswiss_radar/const.py
+++ b/custom_components/meteoswiss_radar/const.py
@@ -3,7 +3,7 @@
 DOMAIN = "meteoswiss_radar"
 
 # Keep in sync with manifest.json and the card's CARD_VERSION.
-VERSION = "0.7.7"
+VERSION = "0.8.0"
 
 UPSTREAM_BASE = "https://www.meteoschweiz.admin.ch"
 

--- a/custom_components/meteoswiss_radar/frontend/meteoswiss-radar-card.js
+++ b/custom_components/meteoswiss_radar/frontend/meteoswiss-radar-card.js
@@ -4,7 +4,7 @@
  * authenticated proxy. Frame format: see FORMAT.md in the repository root.
  */
 
-const CARD_VERSION = "0.7.7";
+const CARD_VERSION = "0.8.0";
 const FRONTEND_BASE = "/meteoswiss_radar/frontend";
 const PROXY_BASE = "meteoswiss_radar/proxy"; // hass.callApi() prepends /api/
 

--- a/custom_components/meteoswiss_radar/manifest.json
+++ b/custom_components/meteoswiss_radar/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/chriguschneider/hass-meteoswiss-radar/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "0.7.7"
+  "version": "0.8.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hass-meteoswiss-radar-card",
-  "version": "0.7.6",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "description": "Tests and syntax checks for the MeteoSwiss Radar Lovelace card.",

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -36,10 +36,21 @@ def _card_version() -> str:
     return match.group(1)
 
 
+def _package_version() -> str:
+    return json.loads((ROOT / "package.json").read_text(encoding="utf-8"))["version"]
+
+
 def test_versions_are_in_sync() -> None:
+    """All four version strings must move together.
+
+    package.json was left out of this check until #64 and had silently drifted
+    a patch release behind, so `npm test` printed a version the card did not
+    ship as. Every file that carries the version belongs here, or it drifts.
+    """
     manifest_version = _manifest()["version"]
-    assert _const_version() == manifest_version
-    assert _card_version() == manifest_version
+    assert _const_version() == manifest_version, "const.py VERSION out of sync"
+    assert _card_version() == manifest_version, "card CARD_VERSION out of sync"
+    assert _package_version() == manifest_version, "package.json version out of sync"
 
 
 def test_manifest_has_required_keys() -> None:


### PR DESCRIPTION
Closes #64.

## The drift

`test_versions_are_in_sync` checked three of the four version strings. `package.json`
was not among them, and it had drifted: still `0.7.6` from #21, while
`manifest.json`, `const.py` and `CARD_VERSION` moved to `0.7.7` in #61. `npm test`
therefore printed a version the card did not ship as.

Now covered. Verified the check actually bites: temporarily set `package.json` to
`0.7.9`, ran the test, watched it fail, restored.

## The bump

All four to **0.8.0**. Minor rather than patch:

- #53 rewrote the geometry layout (single buffer per area + `Int32Array` ring offsets)
- the HA minimum was corrected to 2024.7 in #63, having been wrongly declared as
  2024.6 — that is a break for anyone on 2024.6

## Why the bump matters beyond bookkeeping

HACS compares version strings to decide whether an update exists. The version sat at
`0.7.6` across roughly 15 merged PRs (#46, #49–#61, #63), so an install that had
already downloaded `0.7.6` saw `installed_version == available_version` and was never
offered any of that work. Confirmed against a live instance: `pending_update: false`
with all of the above already merged.

The versioned vendor asset URLs (`/vendor/{VERSION}/leaflet.js`) also pick up the new
version, so the browser cache busts on upgrade.

## Verification

- `python -m pytest -q` → 54 passed
- `npm test` → 101 passed
- `python -m ruff check custom_components tests` → clean

## Note

An earlier `0.7.6` release tag was published against a tree whose manifest already
read `0.7.7` — my error. It should be deleted; `0.8.0` supersedes it either way,
since HACS takes the newest release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)