### PR TITLE
UX: config-only layer switching — remove on-card toggles (issue #131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ the two existing tags (`0.7.6`, `0.8.0`) keep their original form.
 
 ## [Unreleased]
 
+## [v0.11.0] — 2026-08-24
+
+### Changed
+
+- Card: layers are now switched only in the card configuration and an enabled
+  layer is always shown — the on-card toggle buttons (which collided with the
+  +/- zoom controls and lost their state on every dashboard reload) are gone;
+  the legacy `layer_<x>_on` keys are ignored (#131)
+- Card: editor chip changes for `layer_*` now apply to a live card without a
+  full re-init (#131)
+
+### Fixed
+
+- Card: refresh `lightning.json` on its own version, independent of the
+  animation product — a stalled animation version no longer pins stale strike
+  data on the newest frames (live-verified during the 2026-08-24 thunderstorm;
+  #131)
+
 ## [v0.10.0] — 2026-08-24
 
 ### Added
@@ -108,7 +126,8 @@ and test improvements from the 2026-08-22 architecture review.
   for the card decoder (#16); full proxy allowlist, cache-header, and
   lifecycle coverage (#17)
 
-[Unreleased]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.11.0...HEAD
+[v0.11.0]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.10.0...v0.11.0
 [v0.10.0]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.9.0...v0.10.0
 [v0.9.0]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/0.8.0...v0.9.0
 [0.8.0]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/0.7.6...0.8.0

--- a/README.md
+++ b/README.md
@@ -102,16 +102,16 @@ play the configured window (looping) -> play the full timeline.
 
 ### Overlay layers
 
-Four optional layers can be enabled per card. Each adds a toggle button (top-left map corner) and a legend swatch.
+Four optional layers can be enabled per card. An enabled layer is always shown and adds a legend swatch; layers are switched in the card configuration (UI editor chips or YAML), not on the map.
 
-| Config key | Toggle label | What it shows |
+| Config key | Legend label | What it shows |
 | --- | --- | --- |
 | `layer_snow: true` | Snow | INCA snow-type contours |
 | `layer_snowrain: true` | Sleet | INCA sleet-type contours |
 | `layer_freezing_rain: true` | Freezing rain | INCA freezing-rain-type contours |
 | `layer_lightning: true` | Lightning | Strike points from the MeteoSwiss lightning product |
 
-Add `layer_<x>_on: true` alongside the corresponding `layer_<x>: true` to start the overlay visible instead of toggled off.
+The `layer_<x>_on` keys from v0.10.0 are obsolete and ignored (enabled now means visible).
 
 **Snow and Sleet note:** precipitation-type predictions exist only for future (forecast) frames. The overlays are empty on all measurement frames — the map shows nothing while viewing recorded data, matching the app's own behavior.
 

--- a/custom_components/meteoswiss_radar/const.py
+++ b/custom_components/meteoswiss_radar/const.py
@@ -3,7 +3,7 @@
 DOMAIN = "meteoswiss_radar"
 
 # Keep in sync with manifest.json and the card's CARD_VERSION.
-VERSION = "0.10.0"
+VERSION = "0.11.0"
 
 UPSTREAM_BASE = "https://www.meteoschweiz.admin.ch"
 

--- a/custom_components/meteoswiss_radar/frontend/meteoswiss-radar-card.js
+++ b/custom_components/meteoswiss_radar/frontend/meteoswiss-radar-card.js
@@ -4,7 +4,7 @@
  * authenticated proxy. Frame format: see FORMAT.md in the repository root.
  */
 
-const CARD_VERSION = "0.10.0";
+const CARD_VERSION = "0.11.0";
 const FRONTEND_BASE = "/meteoswiss_radar/frontend";
 const PROXY_BASE = "meteoswiss_radar/proxy"; // hass.callApi() prepends /api/
 
@@ -56,17 +56,11 @@ const OVERLAY_URL_KEY = {
 };
 // Z-order: rate layer first, then snow, snowrain, freezing-rain (app parity).
 const OVERLAY_ORDER = ["snow", "snowrain", "freezingrain"];
-// Config key enabling the toggle button for each overlay.
+// Config key enabling each overlay layer (enabled = fetched and shown; issue #131).
 const OVERLAY_CONFIG_KEY = {
   snow: "layer_snow",
   snowrain: "layer_snowrain",
   freezingrain: "layer_freezing_rain",
-};
-// Config key for wall-tablet auto-on default.
-const OVERLAY_ON_KEY = {
-  snow: "layer_snow_on",
-  snowrain: "layer_snowrain_on",
-  freezingrain: "layer_freezing_rain_on",
 };
 
 /* Parse lightning.json → Map<ts(number), [[lat,lng], ...]>.
@@ -493,17 +487,13 @@ class MeteoSwissRadarCard extends HTMLElement {
     // the grace window). null when the card was manually paused at disconnect.
     this._playModeBeforeDetach = null;
     // RadarLayer instances for precipitation-type overlay layers (snow, snowrain,
-    // freezingrain). Created in _createMap for each layer enabled in config.
+    // freezingrain). Created in _createMap for each layer enabled in config;
+    // an enabled layer is always shown (config-only switching, issue #131).
     this._overlayLayers = {};
-    // Per-overlay toggle state: true = overlay is currently displayed on the map.
-    // Initialised from layer_<x>_on config in _createMap; flipped by the map
-    // toggle buttons. Independent of _overlayLayers (a layer can exist but be off).
-    this._overlayActive = {};
     // Lightning point-data overlay: fetched once per version, filtered per frame.
     this._lightningMap = null;      // Map<ts, [[lat,lng]]> parsed from lightning.json
     this._lightningVersion = null;  // version string of the last successful fetch
     this._lightningLayer = null;    // LightningLayer canvas layer (or null if not enabled)
-    this._lightningActive = false;  // toggle state: true = overlay visible
   }
 
   setConfig(config) {
@@ -566,12 +556,58 @@ class MeteoSwissRadarCard extends HTMLElement {
     // back on so the (previously skipped) rows are populated.
     if (timeAxis && prev.time_axis === false) this._buildTimelineLabels();
     if (c.large_label !== prev.large_label) this._updateLabel();
+    this._applyLayerConfigInPlace(c);
     // Only a changed time span needs new frames. Compare as strings so an
     // absent bound on both sides reads as unchanged (Number(undefined) is NaN,
     // and NaN !== NaN would spuriously trigger a reload on every keystroke).
     const span = (cfg) => `${cfg.past_hours}|${cfg.forecast_hours}`;
     if (this._dataReady && span(c) !== span(prev)) {
       this._refreshManifest(true).catch(() => {});
+    }
+  }
+
+  // Create/remove overlay and lightning layers on the live map so editor chip
+  // toggles take effect without a full re-init (config-only switching, #131).
+  _applyLayerConfigInPlace(c) {
+    const L = window.L;
+    if (!this._map || !L) return;
+    let changed = false;
+    for (const key of OVERLAY_ORDER) {
+      const enabled = !!c[OVERLAY_CONFIG_KEY[key]];
+      const layer = this._overlayLayers[key];
+      if (enabled && !layer) {
+        const RadarLayer = makeRadarLayerClass(L);
+        this._overlayLayers[key] = new RadarLayer().addTo(this._map);
+        changed = true;
+      } else if (!enabled && layer) {
+        this._map.removeLayer(layer);
+        delete this._overlayLayers[key];
+        changed = true;
+      }
+    }
+    if (c.layer_lightning && !this._lightningLayer) {
+      const LightningLayer = makeLightningLayerClass(L);
+      this._lightningLayer = new LightningLayer().addTo(this._map);
+      // Strike data was never fetched while the layer was off; the refresh picks
+      // it up via the version check without reloading the animation manifest.
+      this._lightningVersion = null;
+      this._refreshManifest(false).catch(() => {});
+      changed = true;
+    } else if (!c.layer_lightning && this._lightningLayer) {
+      this._map.removeLayer(this._lightningLayer);
+      this._lightningLayer = null;
+      this._lightningMap = null;
+      this._lightningVersion = null;
+      changed = true;
+    } else if (changed && this._lightningLayer) {
+      // Re-add so strikes stay above any newly created contour overlay.
+      this._map.removeLayer(this._lightningLayer);
+      this._lightningLayer.addTo(this._map);
+    }
+    if (changed) {
+      this._showOverlaysForFrame(this._frameIndex);
+      this._showLightningForFrame(this._frameIndex);
+      this._updateOverlayLegend();
     }
   }
 
@@ -650,11 +686,9 @@ class MeteoSwissRadarCard extends HTMLElement {
     }
     this._radar = null;
     this._overlayLayers = {};
-    this._overlayActive = {};
     this._lightningLayer = null;
     this._lightningMap = null;
     this._lightningVersion = null;
-    this._lightningActive = false;
     this._pending.clear();
     this._retryAfter.clear();
     this._frames = [];
@@ -867,20 +901,6 @@ class MeteoSwissRadarCard extends HTMLElement {
           font-size: 9px; white-space: nowrap; pointer-events: none;
           font-family: var(--primary-font-family, sans-serif);
         }
-        #layertoggles {
-          position: absolute; top: 8px; left: 8px; z-index: 1000;
-          display: flex; flex-direction: column; gap: 4px;
-        }
-        #layertoggles .ltbtn {
-          width: 28px; height: 28px; border-radius: 4px; border: none;
-          cursor: pointer; display: flex; align-items: center; justify-content: center;
-          background: var(--card-background-color, #fff); opacity: 0.85;
-          box-shadow: 0 1px 4px rgba(0,0,0,0.3);
-          transition: opacity 0.15s;
-        }
-        #layertoggles .ltbtn.active { opacity: 1; }
-        #layertoggles .ltbtn.forecast-only:disabled { opacity: 0.4; cursor: not-allowed; }
-        #layertoggles .ltbtn svg { display: block; }
         #overlay-swatches { margin-top: 4px; border-top: 1px solid var(--divider-color, #e0e0e0); padding-top: 3px; }
         #overlay-swatches .cell { display: flex; align-items: center; gap: 5px; }
         #overlay-swatches .cell i {
@@ -898,7 +918,6 @@ class MeteoSwissRadarCard extends HTMLElement {
           <div id="map"></div>
           <div id="label" hidden><div id="label-l1" class="l1"></div><div id="label-l2" class="l2" hidden></div></div>
           <div id="banner" hidden></div>
-          <div id="layertoggles" hidden></div>
           <button id="play" aria-label="Play/Pause" hidden>${PLAY_SVG}</button>
           <div id="legend" hidden>
             <div class="title">mm/h</div>
@@ -928,7 +947,6 @@ class MeteoSwissRadarCard extends HTMLElement {
     this._labelL1 = root.getElementById("label-l1");
     this._labelL2 = root.getElementById("label-l2");
     this._banner = root.getElementById("banner");
-    this._layerTogglesEl = root.getElementById("layertoggles");
     this._overlaySwatch = root.getElementById("overlay-swatches");
     this._timeline = root.getElementById("timeline");
     this._trackWrap = root.getElementById("trackwrap");
@@ -1020,126 +1038,22 @@ class MeteoSwissRadarCard extends HTMLElement {
     // Rate layer first, then overlay layers in z-order (snow < snowrain < freezingrain).
     this._radar = new RadarLayer().addTo(this._map);
     this._overlayLayers = {};
-    this._overlayActive = {};
     for (const key of OVERLAY_ORDER) {
-      const cfgKey = OVERLAY_CONFIG_KEY[key];
-      if (!this._config[cfgKey]) continue;
+      if (!this._config[OVERLAY_CONFIG_KEY[key]]) continue;
       this._overlayLayers[key] = new RadarLayer().addTo(this._map);
-      this._overlayActive[key] = !!this._config[OVERLAY_ON_KEY[key]];
     }
     // Lightning layer sits above the contour overlays in z-order.
     this._lightningLayer = null;
-    this._lightningActive = false;
     if (this._config.layer_lightning) {
       const LightningLayer = makeLightningLayerClass(L);
       this._lightningLayer = new LightningLayer().addTo(this._map);
-      this._lightningActive = !!this._config.layer_lightning_on;
     }
-    this._buildLayerToggles();
 
     // The shadow-DOM stylesheet may finish loading after map creation; without
     // a recalc the tiles render misaligned.
     const link = this.shadowRoot.querySelector("link");
     link.addEventListener("load", () => this._map.invalidateSize());
     requestAnimationFrame(() => this._map.invalidateSize());
-  }
-
-  _buildLayerToggles() {
-    if (!this._layerTogglesEl) return;
-    this._layerTogglesEl.textContent = "";
-    let anyEnabled = false;
-    for (const key of OVERLAY_ORDER) {
-      if (!this._overlayLayers[key]) continue;
-      anyEnabled = true;
-      const btn = document.createElement("button");
-      btn.type = "button";
-      btn.className = "ltbtn" + (this._overlayActive[key] ? " active" : "");
-      btn.title = OVERLAY_LABELS[key];
-      btn.setAttribute("aria-label", OVERLAY_LABELS[key]);
-      btn.setAttribute("data-layer", key);
-      // Forecast-only overlays (snow, snowrain) are disabled in measurement frames.
-      if ((key === "snow" || key === "snowrain") && this._frames[this._frameIndex]?.type === "measurement") {
-        btn.disabled = true;
-        btn.setAttribute("aria-disabled", "true");
-        btn.classList.add("forecast-only");
-      }
-      // Coloured swatch SVG: filled when active, grey outline when inactive.
-      btn.innerHTML = this._layerToggleSvg(key, this._overlayActive[key]);
-      btn.addEventListener("click", () => this._toggleOverlay(key));
-      this._layerTogglesEl.appendChild(btn);
-    }
-    // Lightning toggle (separate: point-data layer, not a contour overlay).
-    if (this._lightningLayer) {
-      anyEnabled = true;
-      const btn = document.createElement("button");
-      btn.type = "button";
-      btn.className = "ltbtn" + (this._lightningActive ? " active" : "");
-      btn.title = "Lightning";
-      btn.setAttribute("aria-label", "Lightning");
-      btn.setAttribute("data-layer", "lightning");
-      btn.innerHTML = this._lightningToggleSvg(this._lightningActive);
-      btn.addEventListener("click", () => this._toggleLightning());
-      this._layerTogglesEl.appendChild(btn);
-    }
-    this._layerTogglesEl.hidden = !anyEnabled;
-  }
-
-  _layerToggleSvg(key, active) {
-    const fill = active ? OVERLAY_COLORS[key] : "none";
-    const stroke = active ? OVERLAY_COLORS[key] : "#aaa";
-    return `<svg width="18" height="18" viewBox="0 0 18 18">` +
-      `<rect x="2" y="2" width="14" height="14" rx="2" ry="2"` +
-      ` fill="${fill}" stroke="${stroke}" stroke-width="2"/>` +
-      `</svg>`;
-  }
-
-  _lightningToggleSvg(active) {
-    const fill = active ? LIGHTNING_COLOR : "none";
-    const stroke = active ? "#999" : "#aaa";
-    return `<svg width="18" height="18" viewBox="0 0 18 18">` +
-      `<path d="M10 2L4 10h5l-1 6 7-8h-5z"` +
-      ` fill="${fill}" stroke="${stroke}" stroke-width="1.5" stroke-linejoin="round"/>` +
-      `</svg>`;
-  }
-
-  _toggleLightning() {
-    this._lightningActive = !this._lightningActive;
-    if (this._layerTogglesEl) {
-      const btn = this._layerTogglesEl.querySelector('[data-layer="lightning"]');
-      if (btn) {
-        btn.classList.toggle("active", this._lightningActive);
-        btn.innerHTML = this._lightningToggleSvg(this._lightningActive);
-      }
-    }
-    if (!this._lightningActive) {
-      if (this._lightningLayer) this._lightningLayer.setStrikes([]);
-    } else {
-      this._showLightningForFrame(this._frameIndex);
-    }
-    this._updateOverlayLegend();
-  }
-
-  _toggleOverlay(key) {
-    this._overlayActive[key] = !this._overlayActive[key];
-    // Update the toggle button appearance.
-    if (this._layerTogglesEl) {
-      const btn = this._layerTogglesEl.querySelector(`[data-layer="${key}"]`);
-      if (btn) {
-        btn.classList.toggle("active", this._overlayActive[key]);
-        btn.innerHTML = this._layerToggleSvg(key, this._overlayActive[key]);
-      }
-    }
-    // Clear or redraw the overlay canvas immediately.
-    const layer = this._overlayLayers[key];
-    if (layer) {
-      if (!this._overlayActive[key]) {
-        layer.setFrame(null, null);
-      } else {
-        // Redraw the current frame with this overlay now active.
-        this._showOverlaysForFrame(this._frameIndex);
-      }
-    }
-    this._updateOverlayLegend();
   }
 
   /* ---------- data ---------- */
@@ -1183,8 +1097,10 @@ class MeteoSwissRadarCard extends HTMLElement {
     const versions = await this._api("product/output/versions.json");
     const version = versions["precipitation/animation"];
     if (!version) throw new Error("versions.json has no precipitation/animation entry");
-    if (!force && version === this._animVersion) return;
-    // Fetch lightning.json once per version change; independent of force flag.
+    // Fetch lightning.json once per lightning version — BEFORE the animation
+    // early-return: the two products version independently, and strike buckets
+    // keep filling for minutes after first publication (live-verified
+    // 2026-08-24), so a stalled animation version must not pin stale strikes.
     // Only when the overlay is configured — otherwise the display path (gated on
     // _lightningLayer) never uses it, so fetching it for every card would waste a
     // proxy request (up to ~0.5 MB during a storm) each refresh cycle.
@@ -1203,6 +1119,7 @@ class MeteoSwissRadarCard extends HTMLElement {
           this._lightningVersion = null;
         });
     }
+    if (!force && version === this._animVersion) return;
     const animation = await this._api(
       `product/output/precipitation/animation/version__${version}/de/animation.json`
     );
@@ -1333,13 +1250,11 @@ class MeteoSwissRadarCard extends HTMLElement {
     // Respect an explicit legend:false — the swatches live inside the legend
     // panel, so forcing it visible below would override the user's config.
     const legendOff = this._config && this._config.legend === false;
-    // Collect which overlays are currently active and have a layer.
+    // Collect the enabled overlays (an existing layer is always shown).
     const active = legendOff
       ? []
-      : OVERLAY_ORDER.filter(
-          (key) => this._overlayLayers[key] && this._overlayActive[key]
-        );
-    const lightningOn = !legendOff && this._lightningLayer && this._lightningActive;
+      : OVERLAY_ORDER.filter((key) => this._overlayLayers[key]);
+    const lightningOn = !legendOff && !!this._lightningLayer;
     this._overlaySwatch.textContent = "";
     if (!active.length && !lightningOn) {
       this._overlaySwatch.hidden = true;
@@ -1816,7 +1731,7 @@ class MeteoSwissRadarCard extends HTMLElement {
     }
     // Prefetch overlay frames for upcoming positions, best-effort.
     for (const key of OVERLAY_ORDER) {
-      if (!this._overlayLayers[key] || !this._overlayActive[key]) continue;
+      if (!this._overlayLayers[key]) continue;
       for (const f of upcoming) {
         const url = f[OVERLAY_URL_KEY[key]];
         if (url) this._ensureOverlayFrame(url).catch(() => {});
@@ -1838,7 +1753,7 @@ class MeteoSwissRadarCard extends HTMLElement {
   _showLightningForFrame(idx) {
     const layer = this._lightningLayer;
     if (!layer) return;
-    if (!this._lightningActive || !this._lightningMap) {
+    if (!this._lightningMap) {
       layer.setStrikes([]);
       return;
     }
@@ -1858,10 +1773,6 @@ class MeteoSwissRadarCard extends HTMLElement {
     for (const key of OVERLAY_ORDER) {
       const layer = this._overlayLayers[key];
       if (!layer) continue;
-      if (!this._overlayActive[key]) {
-        layer.setFrame(null, null);
-        continue;
-      }
       const url = f[OVERLAY_URL_KEY[key]];
       if (!url) {
         // Measurement frame or frame without this overlay — clear the canvas.
@@ -1886,7 +1797,6 @@ class MeteoSwissRadarCard extends HTMLElement {
     if (!f) return;
     this._frameIndex = idx;
     this._updateLabel();
-    this._updateForecastOnlyOverlays(f);
     const frac = this._span ? (f.ts - this._t0) / this._span : 0;
     const pct = (frac * 100).toFixed(2) + "%";
     this._tElapsed.style.width = pct;
@@ -1910,19 +1820,6 @@ class MeteoSwissRadarCard extends HTMLElement {
     }
     this._label.dataset.type = f.type;
     this._label.hidden = false;
-  }
-
-  _updateForecastOnlyOverlays(f) {
-    if (!this._layerTogglesEl) return;
-    const isMeasurement = f.type === "measurement";
-    for (const key of ["snow", "snowrain"]) {
-      const btn = this._layerTogglesEl.querySelector(`[data-layer="${key}"]`);
-      if (btn) {
-        btn.classList.toggle("forecast-only", isMeasurement);
-        btn.disabled = isMeasurement;
-        btn.setAttribute("aria-disabled", isMeasurement);
-      }
-    }
   }
 
   /* ---------- status UI ---------- */
@@ -1990,16 +1887,12 @@ const EDITOR_DEFAULTS = {
   attribution: true,
   time_axis: true,
   large_label: true,
-  // Layer toggles: false = overlay button hidden; true = button shown, overlay starts off.
+  // Layers: false = layer off; true = layer fetched and shown (config-only
+  // switching, issue #131 — no on-card toggles; legacy layer_<x>_on keys are ignored).
   layer_snow: false,
   layer_snowrain: false,
   layer_freezing_rain: false,
   layer_lightning: false,
-  // Wall-tablet auto-on: true = overlay toggled on at card load (requires matching layer_<x>: true).
-  layer_snow_on: false,
-  layer_snowrain_on: false,
-  layer_freezing_rain_on: false,
-  layer_lightning_on: false,
 };
 
 const BASICS_SCHEMA = [
@@ -2090,6 +1983,7 @@ const EDITOR_SECTIONS = [
     title: "Layers",
     reset: [
       "layer_snow", "layer_snowrain", "layer_freezing_rain", "layer_lightning",
+      // Legacy auto-on keys: no longer read, but reset still cleans them from old YAML.
       "layer_snow_on", "layer_snowrain_on", "layer_freezing_rain_on", "layer_lightning_on",
     ],
     // defaultOff: true → chip shows ON when value === true (default is false = hidden).

--- a/custom_components/meteoswiss_radar/manifest.json
+++ b/custom_components/meteoswiss_radar/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/chriguschneider/hass-meteoswiss-radar/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "0.10.0"
+  "version": "0.11.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hass-meteoswiss-radar-card",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hass-meteoswiss-radar-card",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "devDependencies": {
         "vitest": "^3.2.4"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hass-meteoswiss-radar-card",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "description": "Tests and syntax checks for the MeteoSwiss Radar Lovelace card.",

--- a/tests/decoder.test.mjs
+++ b/tests/decoder.test.mjs
@@ -85,7 +85,7 @@ function loadDecoder() {
   ctx.globalThis = ctx;
   vm.createContext(ctx);
   vm.runInContext(
-    `${src}\n;globalThis.__decoder = { gridKmToLatLng, decodeContourInto, decodeFrame, frameBytes, DECODE_CACHE_BYTES, SHARED_DECODE_CACHE, MeteoSwissRadarCard, MeteoSwissRadarCardEditor, EDITOR_DEFAULTS, parseLightning, strikesForFrame, makeRadarLayerClass, PATH_CACHE_SIZE };`,
+    `${src}\n;globalThis.__decoder = { gridKmToLatLng, decodeContourInto, decodeFrame, frameBytes, DECODE_CACHE_BYTES, SHARED_DECODE_CACHE, MeteoSwissRadarCard, MeteoSwissRadarCardEditor, EDITOR_DEFAULTS, parseLightning, strikesForFrame, makeRadarLayerClass, PATH_CACHE_SIZE, windowRef: window };`,
     ctx,
     { filename: "meteoswiss-radar-card.js" },
   );
@@ -2700,11 +2700,11 @@ describe("EDITOR_DEFAULTS for overlay layer config keys (issue #92)", () => {
     expect(EDITOR_DEFAULTS.layer_lightning).toBe(false);
   });
 
-  it("all four layer_<x>_on keys default to false (auto-off)", () => {
-    expect(EDITOR_DEFAULTS.layer_snow_on).toBe(false);
-    expect(EDITOR_DEFAULTS.layer_snowrain_on).toBe(false);
-    expect(EDITOR_DEFAULTS.layer_freezing_rain_on).toBe(false);
-    expect(EDITOR_DEFAULTS.layer_lightning_on).toBe(false);
+  it("legacy layer_<x>_on keys are gone from EDITOR_DEFAULTS (issue #131)", () => {
+    expect(EDITOR_DEFAULTS).not.toHaveProperty("layer_snow_on");
+    expect(EDITOR_DEFAULTS).not.toHaveProperty("layer_snowrain_on");
+    expect(EDITOR_DEFAULTS).not.toHaveProperty("layer_freezing_rain_on");
+    expect(EDITOR_DEFAULTS).not.toHaveProperty("layer_lightning_on");
   });
 
   it("layer keys are stripped from emitted config when at their default (false)", () => {
@@ -2850,21 +2850,107 @@ describe("_refreshManifest stores overlay URLs on forecast frames (issue #92)", 
   });
 });
 
-describe("overlay toggle state (_overlayActive) (issue #92)", () => {
-  it("_overlayActive.snow defaults to false when layer_snow_on is absent", () => {
+describe("config-only layer switching (issue #131)", () => {
+  it("_showLightningForFrame draws strikes whenever layer and data exist (no toggle gate)", () => {
     const card = new MeteoSwissRadarCard();
-    card.setConfig({ layer_snow: true });
-    // _overlayActive is populated in _createMap; before that it is an empty object.
-    // After setConfig, overlay state is not yet set (no map created). Verify the
-    // constructor default is an empty object.
-    expect(Object.keys(card._overlayActive)).toHaveLength(0);
+    const calls = [];
+    card._lightningLayer = { setStrikes: (s) => calls.push(s) };
+    card._lightningMap = new Map([[600, [[46.5, 7.5]]]]);
+    card._frames = [
+      { ts: 600, type: "measurement" },
+      { ts: 900, type: "measurement" },
+    ];
+    card._showLightningForFrame(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual([[46.5, 7.5]]);
   });
 
-  it("setConfig merges layer_snow_on: true into the config object", () => {
+  it("_refreshManifest fetches a new lightning version even when the animation version is unchanged", async () => {
     const card = new MeteoSwissRadarCard();
-    card.setConfig({ layer_snow: true, layer_snow_on: true });
-    expect(card._config.layer_snow).toBe(true);
-    expect(card._config.layer_snow_on).toBe(true);
+    card._config = { layer_lightning: true };
+    card._animVersion = "a1";
+    card._lightningVersion = "l1";
+    const requested = [];
+    card._api = (path) => {
+      requested.push(path);
+      if (path.includes("versions.json")) {
+        return Promise.resolve({ "precipitation/animation": "a1", lightning: "l2" });
+      }
+      return Promise.resolve({});
+    };
+    await card._refreshManifest(false);
+    expect(
+      requested.some((p) => p.includes("lightning/version__l2/lightning.json"))
+    ).toBe(true);
+    // The animation early-return still applies: no manifest fetch happened.
+    expect(requested.some((p) => p.includes("animation.json"))).toBe(false);
+  });
+
+  it("_applyLayerConfigInPlace creates and removes overlay layers on a live map", () => {
+    const { MeteoSwissRadarCard: Card, windowRef } = loadDecoder();
+    const card = new Card();
+    const mapLayers = new Set();
+    card._map = {
+      addLayer: (l) => mapLayers.add(l),
+      removeLayer: (l) => mapLayers.delete(l),
+    };
+    card._frames = [];
+    // Minimal Leaflet stub: extend() must yield a constructor whose instances
+    // register themselves on the map via addTo (real onAdd needs map panes).
+    windowRef.L = {
+      Layer: {
+        extend(def) {
+          function C() { if (def.initialize) def.initialize.call(this); }
+          C.prototype = Object.create(def);
+          C.prototype.addTo = function (m) { m.addLayer(this); return this; };
+          return C;
+        },
+      },
+    };
+    try {
+      card._applyLayerConfigInPlace({ layer_snow: true });
+      expect(card._overlayLayers.snow).toBeTruthy();
+      expect(mapLayers.has(card._overlayLayers.snow)).toBe(true);
+      card._applyLayerConfigInPlace({});
+      expect(card._overlayLayers.snow).toBeUndefined();
+      expect(mapLayers.size).toBe(0);
+    } finally {
+      windowRef.L = undefined;
+    }
+  });
+
+  it("_applyLayerConfigInPlace adds and removes the lightning layer with its data", () => {
+    const { MeteoSwissRadarCard: Card, windowRef } = loadDecoder();
+    const card = new Card();
+    const mapLayers = new Set();
+    card._map = {
+      addLayer: (l) => mapLayers.add(l),
+      removeLayer: (l) => mapLayers.delete(l),
+    };
+    card._frames = [];
+    card._api = () => Promise.resolve({});
+    windowRef.L = {
+      Layer: {
+        extend(def) {
+          function C() { if (def.initialize) def.initialize.call(this); }
+          C.prototype = Object.create(def);
+          C.prototype.addTo = function (m) { m.addLayer(this); return this; };
+          return C;
+        },
+      },
+    };
+    try {
+      card._applyLayerConfigInPlace({ layer_lightning: true });
+      expect(card._lightningLayer).toBeTruthy();
+      expect(mapLayers.has(card._lightningLayer)).toBe(true);
+      card._applyLayerConfigInPlace({});
+      expect(card._lightningLayer).toBeNull();
+      expect(card._lightningMap).toBeNull();
+      expect(card._lightningVersion).toBeNull();
+      expect(mapLayers.size).toBe(0);
+    } finally {
+      windowRef.L = undefined;
+    }
   });
 });
 
@@ -2872,7 +2958,6 @@ describe("overlay legend swatches (_updateOverlayLegend) (issue #92)", () => {
   function makeCardWithOverlayEl() {
     const card = new MeteoSwissRadarCard();
     card._overlayLayers = {};
-    card._overlayActive = {};
     card._legendEl = { hidden: false };
     const cells = [];
     card._overlaySwatch = {
@@ -2891,11 +2976,10 @@ describe("overlay legend swatches (_updateOverlayLegend) (issue #92)", () => {
     expect(card._overlaySwatch.hidden).toBe(true);
   });
 
-  it("shows one swatch row per active overlay", () => {
+  it("shows one swatch row per enabled overlay", () => {
     const card = makeCardWithOverlayEl();
-    // Simulate snow and snowrain layers created and active.
+    // Simulate snow and snowrain layers created (enabled = shown, issue #131).
     card._overlayLayers = { snow: {}, snowrain: {} };
-    card._overlayActive = { snow: true, snowrain: true };
     const children = [];
     card._overlaySwatch = {
       hidden: true,
@@ -2908,11 +2992,9 @@ describe("overlay legend swatches (_updateOverlayLegend) (issue #92)", () => {
     expect(children).toHaveLength(2);
   });
 
-  it("hides swatch rows for inactive overlays", () => {
+  it("shows a lightning swatch whenever the lightning layer exists", () => {
     const card = makeCardWithOverlayEl();
-    // Snow layer exists but is toggled off.
-    card._overlayLayers = { snow: {} };
-    card._overlayActive = { snow: false };
+    card._lightningLayer = {};
     const children = [];
     card._overlaySwatch = {
       hidden: true,
@@ -2921,8 +3003,8 @@ describe("overlay legend swatches (_updateOverlayLegend) (issue #92)", () => {
       appendChild(el) { children.push(el); },
     };
     card._updateOverlayLegend();
-    expect(card._overlaySwatch.hidden).toBe(true);
-    expect(children).toHaveLength(0);
+    expect(card._overlaySwatch.hidden).toBe(false);
+    expect(children).toHaveLength(1);
   });
 
   it("suppresses swatches and never forces the legend visible when legend:false", () => {
@@ -2930,7 +3012,6 @@ describe("overlay legend swatches (_updateOverlayLegend) (issue #92)", () => {
     // Active overlay, but the user has explicitly disabled the legend panel.
     card._config = { legend: false };
     card._overlayLayers = { snow: {} };
-    card._overlayActive = { snow: true };
     card._legendEl = { hidden: true };
     const children = [];
     card._overlaySwatch = {


### PR DESCRIPTION
Closes #131.

## What

- **Remove the on-card layer toggle buttons** (lightning + snow/sleet/freezing rain). They collided with the +/- zoom controls, and their state was lost on every dashboard reload — during the 2026-08-24 thunderstorm the card appeared broken while the official app showed strikes.
- **Enabled = visible**: `layer_<x>: true` in the config now means the layer is fetched *and shown*. The legacy `layer_<x>_on` keys are obsolete and ignored (the editor section reset still cleans them out of old YAML).
- **Live config application**: editor chip changes for `layer_*` now create/remove layers on the running card via `_applyLayerConfigInPlace` — no full re-init; the lightning layer is re-added on overlay changes so strikes stay topmost.
- **Lightning refresh decoupled from the animation version**: the `lightning.json` version check now runs *before* the `!force && version === this._animVersion` early return in `_refreshManifest`. The two products version independently and strike buckets keep filling for minutes after first publication (live-verified tonight: version `20260824_1710` had no bucket for the 19:10 frame yet; `1720` did) — a stalled or lagging animation version must not pin stale strikes.

## Verification

- Live data check (2026-08-24 storm): the card's own `parseLightning`/`strikesForFrame`, fed the real manifest + `lightning.json`, produce 11 strikes for the 19:10 frame and 47/61 for 19:20/19:25 — the decode/matching chain is correct; the old toggle default-off plus the version lag were what hid them.
- 200 JS tests green (new: config-only semantics, `_applyLayerConfigInPlace` add/remove for overlays and lightning, and a regression test that a new lightning version is fetched while the animation version is unchanged).
- 121 Python tests green; the 5 `test_vendor_any_tag_resolves` failures are a pre-existing Windows-only path-separator issue, identical on unmodified master (CI runs Linux).
- Version 0.11.0 synced across manifest.json, const.py, CARD_VERSION, package.json, package-lock.json; CHANGELOG section + link added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)