### PR TITLE
fix(ci): add the sonarcloud workflow ADR-0007 decided but never landed

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,51 @@
+name: SonarCloud
+
+# ADR-0007 decided this workflow, but it was never created: #134 shipped
+# sonar-project.properties, the ADR and the README badge without it, so
+# nothing ever ran the scanner and the badge read "Quality gate not
+# computed". This is that missing piece.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sonar-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sonarcloud:
+    name: SonarCloud quality gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # SonarCloud needs full history to attribute new code correctly;
+          # a shallow clone makes every line look new.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - run: pip install pytest pytest-cov
+
+      # Coverage is the reason this runs in CI at all: Automatic Analysis
+      # cannot accept externally produced reports.
+      - name: Pytest with coverage
+        run: pytest -q --cov=custom_components --cov-report=xml
+
+      - name: SonarCloud scan
+        uses: SonarSource/sonarqube-scan-action@v8.2.1
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
+        with:
+          # Block the job on a failing gate rather than reporting green
+          # while the badge says otherwise.
+          args: -Dsonar.qualitygate.wait=true

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ venv/
 node_modules/
 npm-debug.log*
 coverage/
+coverage.xml
 
 # Scratch output for scripts/generate_brands_icon.py. The shipped icon set
 # lives in custom_components/meteoswiss_radar/brand/ and IS committed --

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
   <a href="https://github.com/chriguschneider/hass-meteoswiss-radar/actions/workflows/ci.yml"><img alt="CI status" src="https://img.shields.io/github/actions/workflow/status/chriguschneider/hass-meteoswiss-radar/ci.yml?branch=master&label=CI" /></a>
   <a href="https://sonarcloud.io/summary/overall?id=chriguschneider_hass-meteoswiss-radar&branch=master"><img alt="Quality Gate Status" src="https://sonarcloud.io/api/project_badges/measure?project=chriguschneider_hass-meteoswiss-radar&metric=alert_status" /></a>
   <a href="https://github.com/chriguschneider/hass-meteoswiss-radar/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/chriguschneider/hass-meteoswiss-radar/total" /></a>
-  <a href="https://github.com/chriguschneider/hass-meteoswiss-radar/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/chriguschneider/hass-meteoswiss-radar" /></a>
+  <a href="https://github.com/chriguschneider/hass-meteoswiss-radar/stargazers"><img alt="Stars" src="https://img.shields.io/github/stars/chriguschneider/hass-meteoswiss-radar?style=flat&label=stars" /></a>
+  <a href="https://github.com/chriguschneider/hass-meteoswiss-radar/commits/master"><img alt="Last commit" src="https://img.shields.io/github/last-commit/chriguschneider/hass-meteoswiss-radar" /></a>
+  <a href="https://buymeacoffee.com/chriguschneider"><img alt="Buy Me a Coffee" src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-FFDD00.svg" /></a>
   <a href="#ai-assisted-development"><img alt="AI Assisted" src="https://img.shields.io/badge/AI-assisted-2196F3.svg" /></a>
 </p>
 
@@ -113,6 +115,10 @@ typing, refactors and test scaffolding was
 AI-assisted commits carry a `Co-Authored-By:` trailer, so the history stays
 honest. The badge is there because being upfront about how software gets made
 beats pretending otherwise.
+
+If the card earned a spot on your dashboard,
+[a coffee](https://buymeacoffee.com/chriguschneider) is a nice way to say
+thanks. (Claude doesn't drink coffee. More for me.)
 
 ## Attribution & licence
 


### PR DESCRIPTION
## The quality gate was never wired up

The badge has read **"Quality gate not computed"** since it was added — not a rendering glitch. `#134` shipped `sonar-project.properties`, ADR-0007 and the README badge, but never touched `.github/workflows/`:

```
$ grep -ri sonar .github/     # on master
(no matches)
```

Nothing has ever run the scanner. The SonarCloud API confirms it — the project exists but carries only `ncloc: 3860`, no `alert_status`, no `coverage`. That is what an import with no analysis behind it looks like.

**ADR-0007 names the missing file explicitly** ("Add a `.github/workflows/sonarcloud.yml` workflow that…"), so this PR is not a design decision — it is the unwritten half of an accepted one. `SONAR_TOKEN` was already in place since 2026-08-24.

Implemented per the ADR:

| ADR requirement | Here |
| --- | --- |
| `fetch-depth: 0` | ✅ shallow clones make every line look new |
| Python coverage upload | ✅ `pytest --cov` → `coverage.xml` |
| `sonar.qualitygate.wait=true` | ✅ a failing gate fails the job |
| Skip JS coverage | ✅ still commented out in the properties file |

Verified locally: `pytest -q --cov=custom_components --cov-report=xml` → **158 passed**, `coverage.xml` written. That file was **not** in `.gitignore`, which would have made the new workflow's artifact committable by accident — fixed here too.

## Badges

Aligned with the sibling repo's row:

- **`stars` format.** It was the only badge rendering a capitalised label. `?label=stars` alone is not enough — shields title-cases it in the default style; `?style=flat&label=stars` is what actually works. Verified by reading the rendered SVG, not assumed.
- **Re-added `last commit`**, which I dropped in the shortening pass. On a repo whose main open question is "is this maintained", it earns its place.
- **Added Buy Me a Coffee**, plus one line in the AI section so the badge is not context-free.

**Not added: a "translated N languages" badge.** The sibling has one, but this repo has exactly one locale file (`translations/en.json`) and no i18n in the card at all. It would be decoration for something that does not exist.

All twelve badge URLs were fetched and checked for shields' `invalid` / `not found` fallback text, which renders as a 200. Sonar is the only one still reporting `NOT COMPUTED` — which is precisely what this PR fixes, and will only flip once the workflow runs on `master`.

## Expected on this PR

The SonarCloud job runs here for the first time. If the gate fails on first contact with real analysis, that is a genuine finding about the code rather than a problem with this workflow — worth reading before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
