### PR TITLE
chore(hacs): drop the brands ignore that would disqualify the store submission (#85)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: hacs/action@main
         with:
+          # No `ignore:` here on purpose. HACS default-store inclusion
+          # requires this action to pass "without any errors or ignores",
+          # and the brands check is satisfied by the in-repo
+          # custom_components/meteoswiss_radar/brand/ folder (see
+          # docs/brands-icon.md).
           category: integration
-          # brands is a separate PR to home-assistant/brands, done at release.
-          ignore: brands
 
   python:
     name: Python lint + metadata tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,18 +17,21 @@ the two existing tags (`0.7.6`, `0.8.0`) keep their original form.
   the `home-assistant/brands` CDN, so no PR against that repository is
   needed. Installs on HA older than 2026.3 keep the puzzle piece (#84)
 
-### HACS default store prerequisites verified (#85)
+### Changed
 
-All in-repo prerequisites for the HACS default store submission are met:
-`hacs.json` name present, `manifest.json` with `issue_tracker`/`codeowners`/`version`,
-tagged GitHub release (v0.11.0), `hassfest` and `hacs/action` green on master.
-Open items requiring owner action outside this repo:
-- Add the `integration` GitHub topic (current topics lack it; needs owner access)
-- Confirm whether the brands proxy API (`brand/` folder) satisfies the HACS default
-  store brands requirement, or whether a `home-assistant/brands` PR is still required
-  (see `docs/brands-icon.md` § "Relationship to the HACS default store")
-- Fork `hacs/default`, add `chriguschneider/hass-meteoswiss-radar` to the integration
-  list alphabetically, and open the PR
+- CI: drop `ignore: brands` from the HACS validation job. HACS default-store
+  inclusion requires the action to pass without any ignores, and the check now
+  passes on its own — its validator looks for
+  `custom_components/meteoswiss_radar/brand/icon.png` in the repository tree
+  and only falls back to the `home-assistant/brands` CDN when that is absent
+  (#85)
+
+### Documentation
+
+- `docs/brands-icon.md`: the open question of whether HACS still demands a
+  `home-assistant/brands` entry is answered — it does not, the in-repo `brand/`
+  folder satisfies it, so #84 unblocks #85. Records the validator source and
+  the no-ignores rule behind the CI change (#85)
 
 ## [v0.11.0] — 2026-08-24
 

--- a/docs/brands-icon.md
+++ b/docs/brands-icon.md
@@ -110,10 +110,36 @@ and will still see the puzzle piece. The integration itself supports
 ## Relationship to the HACS default store
 
 Issue #85 (default-store submission) previously listed a brands-repo
-entry as a hard prerequisite. Whether HACS still requires one now that
-integrations can self-host brand images is **unconfirmed** — the proxy
-API announcement does not address HACS publishing. Verify against the
-HACS publisher docs before assuming #84 unblocks #85.
+entry as a hard prerequisite. **Confirmed on 2026-08-25 that it is not**
+— the in-repo `brand/` folder satisfies HACS too, so #84 does unblock
+#85.
+
+HACS runs its own brands validator, and it checks the repository tree
+before it ever looks at the CDN
+([`custom_components/hacs/validate/brands.py`](https://github.com/hacs/integration/blob/main/custom_components/hacs/validate/brands.py)):
+
+```python
+if self.repository.repository_manifest.content_in_root:
+    asset_path = f"brand/{ASSET_FILENAME}"
+else:
+    asset_path = f"{self.repository.content.path.remote}/brand/{ASSET_FILENAME}"
+
+if asset_path in treefiles:
+    return  # local brand assets are enough
+# ... otherwise fall back to home-assistant/brands domains.json
+```
+
+Our `hacs.json` sets `content_in_root: false`, so the path it looks for
+is exactly `custom_components/meteoswiss_radar/brand/icon.png` — which
+this repo ships. The [publisher
+docs](https://www.hacs.xyz/docs/publish/include#check-brands) say the
+same in prose.
+
+One consequence for CI: the same page requires the HACS action to pass
+*“without any errors or ignores”*. `ci.yml` therefore carries **no**
+`ignore: brands` — it used to, back when the plan was a PR against the
+brands repo, and leaving it in would have disqualified the submission
+even though the check now passes on its own merits.
 
 ## Superseded approach
 


### PR DESCRIPTION
## Summary

Refs #85 — deliberately **not** `Closes`. #85 is only done when the
`hacs/default` PR is merged; #166 closed it prematurely and it has been
reopened.

Clears the last in-repo blocker for the HACS default-store submission, and
answers the question that was holding it up.

**The question:** now that #84 ships brand icons inside the integration
(brands proxy API), does HACS still require an entry in
`home-assistant/brands`? `docs/brands-icon.md` had this flagged as
*unconfirmed* — the proxy-API announcement says nothing about HACS
publishing.

**The answer: no.** HACS runs its own brands validator
([`hacs/integration` → `validate/brands.py`](https://github.com/hacs/integration/blob/main/custom_components/hacs/validate/brands.py)),
and it checks the repository tree *before* it ever looks at the CDN:

```python
asset_path = f"{self.repository.content.path.remote}/brand/{ASSET_FILENAME}"
if asset_path in treefiles:
    return  # local brand assets are enough
```

With `content_in_root: false` that resolves to
`custom_components/meteoswiss_radar/brand/icon.png` — shipped since #84. The
[publisher docs](https://www.hacs.xyz/docs/publish/include#check-brands) say
the same in prose. So **#84 unblocks #85**, and no PR against
`home-assistant/brands` is needed.

## The actual change

The same publisher page requires the HACS action to pass *"without any errors
or ignores"*. `ci.yml` carried `ignore: brands`, left over from when the plan
was a brands-repo PR. That ignore was both unnecessary (the check passes) and
disqualifying (it is an ignore). It is gone; the comment in its place explains
why nothing should re-add one.

## Owner actions taken outside this repo

- [x] `integration` topic added to the repository — topics are now
      `custom-card, hacs, home-assistant, homeassistant, integration, lovelace,
      lovelace-card, meteoswiss, radar, switzerland, weather`
- [ ] PR to `hacs/default` adding `chriguschneider/hass-meteoswiss-radar` to
      the `integration` list — opened once this merges, so the reviewer sees a
      `master` with no ignores

## Prerequisite state

| Requirement | State |
| --- | --- |
| `hacs.json` with `name` | ✅ |
| Repo description, issues enabled, topics | ✅ (`integration` added) |
| `manifest.json` with `issue_tracker`, `codeowners`, `version` | ✅ |
| Full GitHub release | ✅ v0.11.0 |
| `hassfest` green | ✅ |
| `hacs/action` green **with no ignores** | ⬅ this PR |
| Brands | ✅ in-repo `brand/` folder (#84) |

## How verified

The HACS validation job in this PR's CI run is the proof — it is the first run
of `hacs/action` on this repo with the brands check actually enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
