### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ the two existing tags (`0.7.6`, `0.8.0`) keep their original form.
 
 ## [Unreleased]
 
+## [v0.12.0] — 2026-08-25
+
 ### Added
 
 - Integration: ship the official MeteoSwiss brand icon in
@@ -25,13 +27,20 @@ the two existing tags (`0.7.6`, `0.8.0`) keep their original form.
   `custom_components/meteoswiss_radar/brand/icon.png` in the repository tree
   and only falls back to the `home-assistant/brands` CDN when that is absent
   (#85)
+- CI: add the SonarCloud quality gate workflow that ADR-0007 decided but
+  #134 never wrote (#165)
 
 ### Documentation
 
+- README: restructured to the `weather-station-card` layout, with the card
+  screenshot (`docs/images/card.png`) no longer a commented-out placeholder,
+  and the option reference split out into `docs/CONFIGURATION.md` (#161)
 - `docs/brands-icon.md`: the open question of whether HACS still demands a
   `home-assistant/brands` entry is answered — it does not, the in-repo `brand/`
   folder satisfies it, so #84 unblocks #85. Records the validator source and
   the no-ignores rule behind the CI change (#85)
+- `docs/brands-icon.md`: verified icon generator and a runnable `gh` block for
+  the brands submission (#84)
 
 ## [v0.11.0] — 2026-08-24
 
@@ -151,7 +160,8 @@ and test improvements from the 2026-08-22 architecture review.
   for the card decoder (#16); full proxy allowlist, cache-header, and
   lifecycle coverage (#17)
 
-[Unreleased]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.12.0...HEAD
+[v0.12.0]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.11.0...v0.12.0
 [v0.11.0]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.10.0...v0.11.0
 [v0.10.0]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.9.0...v0.10.0
 [v0.9.0]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/0.8.0...v0.9.0

--- a/custom_components/meteoswiss_radar/const.py
+++ b/custom_components/meteoswiss_radar/const.py
@@ -3,7 +3,7 @@
 DOMAIN = "meteoswiss_radar"
 
 # Keep in sync with manifest.json and the card's CARD_VERSION.
-VERSION = "0.11.0"
+VERSION = "0.12.0"
 
 UPSTREAM_BASE = "https://www.meteoschweiz.admin.ch"
 

--- a/custom_components/meteoswiss_radar/frontend/meteoswiss-radar-card.js
+++ b/custom_components/meteoswiss_radar/frontend/meteoswiss-radar-card.js
@@ -4,7 +4,7 @@
  * authenticated proxy. Frame format: see FORMAT.md in the repository root.
  */
 
-const CARD_VERSION = "0.11.0";
+const CARD_VERSION = "0.12.0";
 const FRONTEND_BASE = "/meteoswiss_radar/frontend";
 const PROXY_BASE = "meteoswiss_radar/proxy"; // hass.callApi() prepends /api/
 

--- a/custom_components/meteoswiss_radar/manifest.json
+++ b/custom_components/meteoswiss_radar/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/chriguschneider/hass-meteoswiss-radar/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "0.11.0"
+  "version": "0.12.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hass-meteoswiss-radar-card",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hass-meteoswiss-radar-card",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "devDependencies": {
         "@vitest/coverage-v8": "^3.2.7",
         "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hass-meteoswiss-radar-card",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "type": "module",
   "description": "Tests and syntax checks for the MeteoSwiss Radar Lovelace card.",


### PR DESCRIPTION
## Why now

Refs #85 (not `Closes` — that lands with the `hacs/default` PR).

The [hacs/default PR checklist](https://github.com/hacs/default/pull/9650) requires:

> - [ ] The actions are passing without any disabled checks in my repository.
> - [ ] I've created a new release of the repository after the validation actions were run successfully.
>
> Link to successful HACS action (**without the `ignore` key**): …

v0.11.0 fails that on two counts:

1. It was tagged 2026-08-25T03:57, **before** #84 added
   `custom_components/meteoswiss_radar/brand/` — `git ls-tree -r v0.11.0` shows
   zero `brand/` files. Anyone installing the current HACS release gets the
   puzzle-piece icon regardless of #84.
2. It predates #167, the first ignore-free HACS action run on `master`.

## What changed

Version bump only, plus the changelog section. The five files
`test_versions_are_in_sync` guards move together: `manifest.json`, `const.py`,
the card's `CARD_VERSION`, `package.json`, and both `version` keys in
`package-lock.json` (the `@pkgjs/parseargs` dependency, which coincidentally
also sits at `0.11.0`, is left alone).

The changelog section backfills two things that merged without entries:
the README restructure + `docs/CONFIGURATION.md` (#161) and the SonarCloud
workflow (#165).

## How verified

```
python -m pytest -q                     # 158 passed
python -m ruff check custom_components tests   # All checks passed
npm run check                           # node --check, clean at 0.12.0
npm test                                # 211 passed
```

## After merge

Tag `v0.12.0` and create the GitHub release, then open the `hacs/default` PR.

Note for later: ADR-0004 specifies a `.github/workflows/release.yml` that
asserts tag == version and extracts the changelog section. It does not exist —
same gap #165 just closed for ADR-0007. This release is therefore cut by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
