### PR TITLE
fix(ci): produce the JS lcov the SonarCloud scan already expects (#171)

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -40,6 +40,30 @@ jobs:
       - name: Pytest with coverage
         run: pytest -q --cov=custom_components --cov-report=xml
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - run: npm ci
+
+      # The card holds ~2200 of the project's coverable lines. Without this
+      # the scanner finds no lcov, reports the whole file as uncovered, and
+      # the gate fails on new_coverage no matter how good the Python side is.
+      - name: Vitest with coverage
+        run: npm run coverage
+
+      # Sonar only *warns* when a configured report path is missing, so a
+      # silently absent lcov would look like "the card is untested" rather
+      # than "the report never got written". Fail here instead.
+      - name: Assert the JS coverage report exists
+        run: |
+          set -euo pipefail
+          if [ ! -s coverage/lcov.info ]; then
+            echo "::error::coverage/lcov.info is missing or empty; sonar-project.properties expects it."
+            exit 1
+          fi
+          echo "lcov.info: $(wc -l < coverage/lcov.info) lines"
+
       - name: SonarCloud scan
         uses: SonarSource/sonarqube-scan-action@v8.2.1
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules/
 npm-debug.log*
 coverage/
 coverage.xml
+.coverage
 
 # Scratch output for scripts/generate_brands_icon.py. The shipped icon set
 # lives in custom_components/meteoswiss_radar/brand/ and IS committed --

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ the two existing tags (`0.7.6`, `0.8.0`) keep their original form.
   the matching `CHANGELOG.md` section as release notes, and publishes. v0.12.0
   was the last release cut by hand (#170)
 
+### Fixed
+
+- CI: the SonarCloud job now runs `npm run coverage` before the scan. #175
+  taught vitest to attribute the vm-loaded card (0 % → 81 %) and pointed
+  `sonar.javascript.lcov.reportPaths` at `coverage/lcov.info`, but nothing in
+  the workflow ever wrote that file, so the scanner kept seeing the card's
+  ~2200 lines as uncovered and the quality gate stayed red. A guard step now
+  fails loudly if the report is missing, since Sonar only warns (#171)
+
 ## [v0.12.0] — 2026-08-25
 
 ### Added


### PR DESCRIPTION
## Summary

Closes #171 — reopened, because it was closed while the gate was still red.

[#175](https://github.com/chriguschneider/hass-meteoswiss-radar/pull/175) did the hard part and did it well: passing the resolved `cardPath` as the vm script filename lets `v8-to-istanbul` map execution back to the real file. Verified locally on `master`:

```
$ npm run coverage
Tests  211 passed (211)
Statements   : 80.99% ( 1790/2210 )
Branches     : 82.84% ( 367/443 )
Lines        : 80.99% ( 1790/2210 )

$ head -1 coverage/lcov.info
SF:custom_components/meteoswiss_radar/frontend/meteoswiss-radar-card.js
```

**0 % → 81 %.** The premise recorded in `sonar-project.properties` for months — *"V8 cannot attribute execution inside a vm context"* — was wrong; it just needed an absolute filename.

## What was still missing

`#175` also uncommented `sonar.javascript.lcov.reportPaths=coverage/lcov.info`. But `sonarcloud.yml` installs **Python only** and runs `pytest --cov`. Nothing ever writes `coverage/lcov.info`.

So the scanner found no report, kept counting the card's ~2200 lines as uncovered, and the gate stayed red — SonarCloud failed on both `83c4827` and `5a6be35` after #175 and #176 merged.

This adds the three missing steps: `setup-node`, `npm ci`, `npm run coverage`.

## Why the bot could not finish it

Its token has no `workflow` scope. That is exactly what [the split note on #171](https://github.com/chriguschneider/hass-meteoswiss-radar/issues/171#issuecomment-5406361713) predicted — *"it will stall there, same as it did on #85 and #170"*. It did the three files it could reach, and the issue auto-closed on merge with the symptom still live.

## The guard step

Sonar only **warns** when a configured report path is missing; it does not fail. A silently absent lcov then reads as *"the card is untested"* rather than *"the report never got written"* — which is plausibly how the vm limitation came to look permanent in the first place. The job now fails loudly instead.

## Also

`.coverage` (the pytest-cov data file) is gitignored. It sat untracked next to the already-ignored `coverage/` and `coverage.xml`.

## How verified

- `npm ci && npm run coverage` on `master` → 211 tests, 81 % lines, valid `coverage/lcov.info` with the card as its single `SF:` entry
- `sonarcloud.yml` parses; step order is pytest → node → coverage → guard → scan
- The real proof is this PR's own SonarCloud run, which is the first to reach the scanner with a JS report present

## Not fixed here

`new_coverage` must clear 80 %. The card lands at 81.0 % overall, so it should pass — but the New Code period is `previous_version`, and if the newly-attributed lines skew below that, some may still need tests. That is a follow-up, not a reason to hold this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
