### PR TITLE
feat(ci): the CodeQL and smoke-test workflows ADR-0005 and ADR-0006 never got (#180)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+name: CodeQL
+
+# ADR-0005. The proxy's URL handling is the declared security boundary
+# (ADR-0001), and the card runs in the browser -- both deserve a static
+# pass that is not a human reading a diff.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  schedule:
+    # Saturday 02:15 UTC, matching the sibling weather-station-card repo.
+    # A weekly run matters because new CodeQL rules ship continuously: the
+    # value is not re-scanning unchanged code, it is scanning it with
+    # queries that did not exist last week.
+    - cron: "15 2 * * 6"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, python]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+          config: |
+            paths-ignore:
+              # Vendored Leaflet. Third-party code we do not patch; findings
+              # here would be noise we cannot action. Mirrors sonar.exclusions.
+              - custom_components/meteoswiss_radar/frontend/vendor
+              # Binary frame payloads, not source.
+              - tests/fixtures
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,119 @@
+name: Upstream smoke test
+
+# ADR-0006. FORMAT.md is reverse-engineered from an undocumented MeteoSwiss
+# API. If they change the wire format, nothing in this repo breaks -- the
+# decoder just quietly returns nothing, and the first person to find out is
+# a user whose card stopped drawing. This job is the tripwire.
+#
+# Deliberately NOT part of PR checks: upstream drift is not a regression in
+# a pull request, and an upstream outage must not block development.
+
+on:
+  schedule:
+    # Monday 02:00 UTC (ADR-0006). Note GitHub disables cron on repos with
+    # no activity for 60 days -- if this stops running, that is why.
+    - cron: "0 2 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: smoke-test
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Decode live MeteoSwiss frames
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      # No secrets and no dependencies: the script uses urllib against the
+      # unauthenticated API, ~4 requests per run.
+      - name: Run the smoke test
+        id: smoke
+        env:
+          # The script prints U+2713 / U+2717 status marks. On any stdout that
+          # is not UTF-8 the print itself raises, the broad except records it
+          # as a failed check, and the run reports upstream drift that did not
+          # happen. Reproduced on a cp1252 console; pinned here so a runner
+          # locale change can never manufacture a false alert.
+          PYTHONIOENCODING: utf-8
+        run: |
+          set +e
+          python tests/tools/smoke_test.py 2>&1 | tee smoke.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Open or update the drift issue
+        if: steps.smoke.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: "Upstream API format drift detected"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # Keep the issue readable: the tail carries the failure summary the
+          # script prints last.
+          tail -c 4000 smoke.log > log-tail.txt
+
+          {
+            echo "The weekly smoke test could not decode live MeteoSwiss frames."
+            echo
+            echo "- Run: $RUN_URL"
+            echo "- Date: $(date -u +%Y-%m-%dT%H:%MZ)"
+            echo
+            echo "\`\`\`"
+            cat log-tail.txt
+            echo "\`\`\`"
+            echo
+            echo "Per ADR-0006 this is tracked as an external contract change, not a repo regression."
+            echo "Check FORMAT.md against what the API actually returns before touching the decoder."
+          } > body.md
+
+          existing="$(gh issue list --state open --search "$TITLE in:title" \
+            --json number,title --jq "[.[] | select(.title == \"$TITLE\")] | .[0].number // empty")"
+
+          if [ -n "$existing" ]; then
+            echo "Updating existing issue #$existing"
+            gh issue comment "$existing" --body-file body.md
+          else
+            echo "Opening a new drift issue"
+            # Labelled `bug`/`area-integration` on purpose and NOT with a
+            # P-label: the autopilot grinds the P-backlog, and it cannot fix
+            # MeteoSwiss changing their API. A human triages this one.
+            gh issue create --title "$TITLE" --body-file body.md \
+              --label bug --label area-integration
+          fi
+
+      - name: Note recovery on an open drift issue
+        if: steps.smoke.outputs.exit_code == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: "Upstream API format drift detected"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --state open --search "$TITLE in:title" \
+            --json number,title --jq "[.[] | select(.title == \"$TITLE\")] | .[0].number // empty")"
+          if [ -n "$existing" ]; then
+            # Deliberately not closed: decoding again does not prove the
+            # format is unchanged -- an empty frame decodes fine too. A human
+            # confirms and closes.
+            gh issue comment "$existing" --body \
+              "Smoke test passed again on $(date -u +%Y-%m-%d) ($RUN_URL). Left open for a human to confirm the format actually matches FORMAT.md before closing."
+          fi
+
+      - name: Fail the job if the smoke test failed
+        if: steps.smoke.outputs.exit_code != '0'
+        run: |
+          echo "::error::Smoke test exited ${{ steps.smoke.outputs.exit_code }} -- see the drift issue."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ the two existing tags (`0.7.6`, `0.8.0`) keep their original form.
 
 ## [Unreleased]
 
+### Added
+
+- CI: `.github/workflows/codeql.yml` — the static analysis ADR-0005 decided
+  and #134 never wrote. `security-extended` over `javascript-typescript` and
+  `python`, on PRs, on `master`, and weekly (Saturday 02:15 UTC). Vendored
+  Leaflet and the binary test fixtures are excluded, mirroring
+  `sonar.exclusions` (#180)
+- CI: `.github/workflows/smoke-test.yml` — the weekly upstream tripwire
+  ADR-0006 decided and that was likewise never written. Monday 02:00 UTC, it
+  decodes live measurement and forecast frames and, on failure, opens or
+  updates an "Upstream API format drift detected" issue rather than failing
+  PRs. Deliberately labelled `bug`/`area-integration` and **not** with a
+  P-label, so the autopilot does not try to fix MeteoSwiss changing their API
+  (#180)
+
+### Fixed
+
+- `tests/tools/smoke_test.py` reported upstream drift that had not happened
+  when stdout was not UTF-8: the U+2713 status marks fail to encode, the print
+  raises, and the broad `except` records it as a failed check. The workflow
+  pins `PYTHONIOENCODING=utf-8` and the docstring warns anyone running it by
+  hand (#180)
+
 ### Documentation
 
 - `docs/brands-icon.md`: correct two claims that were wrong. The icon does

--- a/tests/tools/smoke_test.py
+++ b/tests/tools/smoke_test.py
@@ -9,6 +9,11 @@ Run from the repo root:
 
     python3 tests/tools/smoke_test.py
 
+On a console that is not UTF-8 (a Windows cp1252 terminal, for instance)
+the status marks below cannot be encoded, the print raises, and the run
+reports a failure that has nothing to do with upstream. Prefix with
+PYTHONIOENCODING=utf-8 there; the workflow sets it already.
+
 Exits with status 0 if all frames decode successfully and geometry is valid.
 Exits with status 1 if any frame fails to fetch, decode, or validate.
 """


### PR DESCRIPTION
## Summary

Closes #180. The last two ADR-to-workflow gaps. Four of seven accepted ADRs were in this state; #165 closed ADR-0007, #173 closed ADR-0004, this closes ADR-0005 and ADR-0006.

## ADR-0005 → `codeql.yml`

`security-extended` over `javascript-typescript` and `python`, on PRs, on `master`, and weekly (Saturday 02:15 UTC, matching the sibling repo).

Worth stating plainly: before this, `code-scanning/default-setup` was `not-configured`. **Nothing was statically analysing the proxy's URL handling** — the thing ADR-0001 names as this repo's security boundary.

Vendored Leaflet and `tests/fixtures` are excluded via inline `paths-ignore`, mirroring `sonar.exclusions`. Findings in third-party code we do not patch are noise, and noise is how a security gate gets ignored.

Per ADR-0005 the initial findings must be triaged before merge — confirmed ones fixed here, false positives suppressed with a one-line reason. **That triage happens on this PR's own CodeQL run**, which is the first one that can exist. I will report what it finds before merging.

## ADR-0006 → `smoke-test.yml`

Monday 02:00 UTC. Decodes one live measurement frame and one INCA forecast frame, ~4 unauthenticated requests, no secrets.

On failure it **opens or updates** an issue titled "Upstream API format drift detected" rather than failing anything. Per the ADR, drift is an external contract change, not a repo regression.

Two deliberate choices:

- The drift issue carries `bug` + `area-integration` and **no P-label**. The autopilot grinds the P-backlog; pointing it at "MeteoSwiss changed their API" would burn tokens on something it cannot fix.
- A recovery run comments but does **not** close the issue. An empty frame decodes fine too, so a passing run is not proof the format is unchanged — a human confirms against FORMAT.md.

## The bug this turned up

Running the script for real, before wiring a cron to it, it failed — and not because of upstream:

```
UnicodeEncodeError: 'charmap' codec can't encode character '✗'
```

It prints `✓`/`✗` status marks. On stdout that is not UTF-8, the print itself raises, the broad `except` records that as a failed check, and the run reports drift that never happened. Reproduced on a cp1252 console.

That is the worst possible failure mode for a weekly alarm: it would have opened a false drift issue, and a tripwire that cries wolf gets muted. The workflow now pins `PYTHONIOENCODING=utf-8` so a runner locale change cannot manufacture one, and the docstring warns anyone running it by hand.

## How verified

Live, today, with the encoding fixed:

```
=== Fetching measurement frame ===   ✓ 9 areas, 34814 vertices decoded   ✓ Geometry valid
=== Fetching forecast frame (INCA rate) ===   ✓ 8 areas, 628 vertices decoded   ✓ Geometry valid
✓ All checks passed        (exit 0)
```

Plus `pytest -q` → 158 passed, `ruff check` → clean, both workflows parse.

## Not verified

The cron paths. Neither schedule can be exercised without waiting for it; `smoke-test.yml` has `workflow_dispatch` so it can be triggered by hand, `codeql.yml` runs on this PR.

The drift-issue branch is also untested — it only runs when upstream actually breaks. It is plain `gh issue list`/`create`/`comment`, but it is code that has never executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
