### PR TITLE
chore(release): v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ the two existing tags (`0.7.6`, `0.8.0`) keep their original form.
 
 ## [Unreleased]
 
+## [v0.13.0] — 2026-08-25
+
 ### Added
 
 - CI: `.github/workflows/codeql.yml` — the static analysis ADR-0005 decided
@@ -22,6 +24,11 @@ the two existing tags (`0.7.6`, `0.8.0`) keep their original form.
   PRs. Deliberately labelled `bug`/`area-integration` and **not** with a
   P-label, so the autopilot does not try to fix MeteoSwiss changing their API
   (#180)
+- CI: `.github/workflows/release.yml`, the tag-triggered release gate ADR-0004
+  specified but that was never written. On a `v*` tag it asserts the tag
+  against `manifest.json`, refuses to overwrite an existing release, extracts
+  the matching `CHANGELOG.md` section as release notes, and publishes. v0.12.0
+  was the last release cut by hand (#170)
 
 ### Fixed
 
@@ -30,6 +37,12 @@ the two existing tags (`0.7.6`, `0.8.0`) keep their original form.
   raises, and the broad `except` records it as a failed check. The workflow
   pins `PYTHONIOENCODING=utf-8` and the docstring warns anyone running it by
   hand (#180)
+- CI: the SonarCloud job now runs `npm run coverage` before the scan. #175
+  taught vitest to attribute the vm-loaded card (0 % → 81 %) and pointed
+  `sonar.javascript.lcov.reportPaths` at `coverage/lcov.info`, but nothing in
+  the workflow ever wrote that file, so the scanner kept seeing the card's
+  ~2200 lines as uncovered and the quality gate stayed red. A guard step now
+  fails loudly if the report is missing, since Sonar only warns (#171)
 
 ### Documentation
 
@@ -42,23 +55,6 @@ the two existing tags (`0.7.6`, `0.8.0`) keep their original form.
   refuses new custom components and 15 such PRs were rejected in the five days
   to 2026-08-25. Records the live measurements and the HACS-side fix in
   flight (`hacs/integration#5388`) (#84)
-
-### Added
-
-- CI: `.github/workflows/release.yml`, the tag-triggered release gate ADR-0004
-  specified but that was never written. On a `v*` tag it asserts the tag
-  against `manifest.json`, refuses to overwrite an existing release, extracts
-  the matching `CHANGELOG.md` section as release notes, and publishes. v0.12.0
-  was the last release cut by hand (#170)
-
-### Fixed
-
-- CI: the SonarCloud job now runs `npm run coverage` before the scan. #175
-  taught vitest to attribute the vm-loaded card (0 % → 81 %) and pointed
-  `sonar.javascript.lcov.reportPaths` at `coverage/lcov.info`, but nothing in
-  the workflow ever wrote that file, so the scanner kept seeing the card's
-  ~2200 lines as uncovered and the quality gate stayed red. A guard step now
-  fails loudly if the report is missing, since Sonar only warns (#171)
 
 ## [v0.12.0] — 2026-08-25
 
@@ -212,7 +208,8 @@ and test improvements from the 2026-08-22 architecture review.
   for the card decoder (#16); full proxy allowlist, cache-header, and
   lifecycle coverage (#17)
 
-[Unreleased]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.13.0...HEAD
+[v0.13.0]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.12.0...v0.13.0
 [v0.12.0]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.11.0...v0.12.0
 [v0.11.0]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.10.0...v0.11.0
 [v0.10.0]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.9.0...v0.10.0

--- a/custom_components/meteoswiss_radar/const.py
+++ b/custom_components/meteoswiss_radar/const.py
@@ -3,7 +3,7 @@
 DOMAIN = "meteoswiss_radar"
 
 # Keep in sync with manifest.json and the card's CARD_VERSION.
-VERSION = "0.12.0"
+VERSION = "0.13.0"
 
 UPSTREAM_BASE = "https://www.meteoschweiz.admin.ch"
 

--- a/custom_components/meteoswiss_radar/frontend/meteoswiss-radar-card.js
+++ b/custom_components/meteoswiss_radar/frontend/meteoswiss-radar-card.js
@@ -4,7 +4,7 @@
  * authenticated proxy. Frame format: see FORMAT.md in the repository root.
  */
 
-const CARD_VERSION = "0.12.0";
+const CARD_VERSION = "0.13.0";
 const FRONTEND_BASE = "/meteoswiss_radar/frontend";
 const PROXY_BASE = "meteoswiss_radar/proxy"; // hass.callApi() prepends /api/
 

--- a/custom_components/meteoswiss_radar/manifest.json
+++ b/custom_components/meteoswiss_radar/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/chriguschneider/hass-meteoswiss-radar/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "0.12.0"
+  "version": "0.13.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hass-meteoswiss-radar-card",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hass-meteoswiss-radar-card",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "devDependencies": {
         "@vitest/coverage-v8": "^3.2.7",
         "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hass-meteoswiss-radar-card",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "type": "module",
   "description": "Tests and syntax checks for the MeteoSwiss Radar Lovelace card.",


### PR DESCRIPTION
## Summary

v0.13.0 — the release that closes the last ADR-to-workflow gap.

Four of seven accepted ADRs had specified a workflow that was never written. This release contains the last two, so `docs/adr/` and `.github/workflows/` finally agree:

| ADR | Workflow | Closed by |
| --- | --- | --- |
| 0004 tag-triggered release gate | `release.yml` | #173 |
| 0005 CodeQL | `codeql.yml` | #181 |
| 0006 scheduled smoke test | `smoke-test.yml` | #181 |
| 0007 SonarCloud | `sonarcloud.yml` | #165 |

Plus the SonarCloud lcov fix (#171) that took new-code coverage from 44.5 % to 86.6 %, and the `docs/brands-icon.md` correction (#84).

## This is the first release `release.yml` cuts itself

v0.12.0 was tagged and published by hand, which is exactly what ADR-0004 exists to prevent. From here the procedure is: bump the five version-synced files → write the `## [vX.Y.Z]` section → `git tag -a` → push. CI asserts the tag against `manifest.json`, refuses to overwrite an existing release, extracts the changelog section as notes, and publishes.

So this PR is also the workflow's first real test. If it misbehaves, it does so on a release that is trivially re-cuttable.

## Changelog hygiene

The `[Unreleased]` section had accumulated **two `### Added` and two `### Fixed`** headings, because #173, #177 and #181 each appended their own. Merged into one heading per type, order preserved.

## How verified

```
python -m pytest -q                            # 158 passed
python -m ruff check custom_components tests   # All checks passed
npm run check                                  # clean at 0.13.0
npm test                                       # 211 passed
```

`test_versions_are_in_sync` covers all five version carriers — `manifest.json`, `const.py`, `CARD_VERSION`, `package.json`, and both `package-lock.json` keys.

## On 1.0

Not yet, and deliberately. The quality bar is there — 82.5 % coverage, every gate green, CodeQL clean, ADRs and implementation aligned. What is missing is users: 0 downloads, 1 star, a forum thread with no replies, and #10323 still queued. A 1.0 is a promise that the config surface is stable, and that surface has had exactly one user and broke one release ago (v0.11.0 dropped the on-card layer toggles). It is worth making that promise after #10323 merges and real installs have exercised it — not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
