### PR TITLE
fix(ci): read the release title from the tag object, not the checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,19 +95,35 @@ jobs:
       # Releases here are titled "<tag> — <what changed>" (e.g. "v0.11.0 —
       # radar overlay layers"). Nothing in the repo can derive that phrase,
       # so it comes from the annotated tag's own message:
-      #     git tag -a v0.13.0 -m "radar overlay layers"
-      # Only annotated tags are consulted: for a lightweight one,
-      # %(contents:subject) silently falls through to the commit subject,
-      # which would title the release "chore(release): ... (#65)".
+      #     git tag -a v0.13.0 -m "what changed"
+      #
+      # Read via the API, not `git tag -l`, because the checked-out ref is
+      # not the tag we pushed. actions/checkout fetches the real tags and
+      # then force-overwrites the one it wants with the resolved commit:
+      #
+      #   fetch ... +refs/tags/*:refs/tags/*
+      #   fetch --no-tags ... +<commit-sha>:refs/tags/v0.13.0     <-- clobbers
+      #
+      # so `git cat-file -t v0.13.0` reports `commit` locally even for an
+      # annotated tag, and the message is unreachable. v0.13.0 shipped titled
+      # bare because of this.
+      #
+      # Only annotated tags carry a subject: for a lightweight one the API
+      # returns object.type == "commit", and `git tag -l` would have fallen
+      # through to the *commit* subject, titling 0.8.0 "chore(release): 0.8.0,
+      # and cover package.json in the version-sync test (#65)".
       - name: Build the release title
         id: title
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           tag="${{ steps.version.outputs.tag }}"
-          if [ "$(git cat-file -t "$tag")" = "tag" ]; then
-            subject="$(git tag -l --format='%(contents:subject)' "$tag")"
-          else
-            subject=""
+          object_type="$(gh api "repos/${{ github.repository }}/git/ref/tags/$tag" --jq '.object.type')"
+          subject=""
+          if [ "$object_type" = "tag" ]; then
+            object_sha="$(gh api "repos/${{ github.repository }}/git/ref/tags/$tag" --jq '.object.sha')"
+            subject="$(gh api "repos/${{ github.repository }}/git/tags/$object_sha" --jq '.message' | head -1)"
           fi
           # Tolerate a message that already repeats the tag, so
           # `-m "v0.13.0 — foo"` yields one "v0.13.0 —", not two.
@@ -121,6 +137,7 @@ jobs:
           else
             title="$tag"
           fi
+          echo "Tag object type: $object_type"
           echo "Release title: $title"
           echo "title=$title" >> "$GITHUB_OUTPUT"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ the two existing tags (`0.7.6`, `0.8.0`) keep their original form.
 
 ## [Unreleased]
 
+### Fixed
+
+- CI: `release.yml` now reads the annotated tag's message through the GitHub
+  API instead of `git tag -l`. `actions/checkout` fetches the real tags and
+  then force-overwrites the triggering one with the resolved commit
+  (`+<sha>:refs/tags/<tag>`), so locally the tag reports as a `commit` and its
+  message is unreachable — v0.13.0 shipped titled bare `v0.13.0` instead of
+  carrying its subject. The lightweight-tag guard is preserved, so a bare tag
+  still cannot title a release with a commit subject (#183)
+
 ## [v0.13.0] — 2026-08-25
 
 ### Added


### PR DESCRIPTION
## What happened

v0.13.0 published correctly — notes extracted, tag verified, `github-actions[bot]` as author — but titled bare `v0.13.0`, even though it was tagged `git tag -a v0.13.0 -m "the last two ADR workflow gaps closed"`.

## Why

`actions/checkout` does two fetches on a tag trigger. From the run log:

```
git fetch --prune ... origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
git fetch --no-tags ... origin +de5e12cdcc08f5252b8b4e91d8206c13a61a7eb5:refs/tags/v0.13.0
git checkout --progress --force refs/tags/v0.13.0
```

The first fetch brings the real annotated tag. **The second overwrites it** with the resolved commit SHA. So in the checkout, `v0.13.0` is a lightweight tag pointing at a commit — `git cat-file -t` reports `commit`, the guard takes the lightweight branch, and the message is unreachable.

The step logged `Release title: v0.13.0` and the job passed. Nothing failed; the title was just quietly wrong. Which is the annoying class of bug — [#177](https://github.com/chriguschneider/hass-meteoswiss-radar/pull/177) was the same shape, a missing report that only warned.

## Fix

Read the tag object through the API, which sees it as pushed rather than as checkout rewrote it:

```
gh api repos/{repo}/git/ref/tags/{tag}   --jq .object.type   # "tag" | "commit"
gh api repos/{repo}/git/tags/{sha}       --jq .message
```

Verified against all three shapes present in this repo's history:

| Tag | `object.type` | Resulting title |
| --- | --- | --- |
| `v0.13.0` | `tag` | `v0.13.0 — the last two ADR workflow gaps closed` |
| `v0.11.0` | `tag` (message repeats the tag) | `v0.11.0 — radar overlay layers …` — no doubling |
| `0.8.0` | `commit` (lightweight) | `0.8.0` |

## The guard stays

The lightweight check is not redundant. `%(contents:subject)` silently falls through to the **commit** subject for a lightweight tag, which is how `0.8.0` would have been titled *"0.8.0 — chore(release): 0.8.0, and cover package.json in the version-sync test (#65)"*. The API's `object.type` is now what distinguishes them, rather than local git state that checkout has already rewritten.

## Not verified

Same limitation as before: the workflow only runs on a tag push, and a tag push publishes a real release. This runs for the first time at v0.14.0. The API calls themselves were exercised against all three tags above.

The v0.13.0 release title is corrected by hand separately — the release itself is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
