### PR TITLE
feat(hacs): ship a zip release asset so installs are countable (ADR-0008)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,49 @@ jobs:
           echo "Release title: $title"
           echo "title=$title" >> "$GITHUB_OUTPUT"
 
-      # No assets: HACS downloads the repository zip for integrations.
+      # ADR-0008. HACS increments a release's download counter only when it
+      # pulls a release *asset*, and it only does that when hacs.json sets
+      # zip_release with a .zip filename -- see should_try_releases in HACS'
+      # repositories/base.py. Without it an integration is installed by
+      # walking the repo tree, so the counter stays at zero however many
+      # people install. That is what happened to 0.7.6 through v0.13.0.
+      #
+      # Layout matters: the zip holds the *contents* of the integration
+      # directory at its root, not the directory itself. HACS extracts it
+      # straight into custom_components/<domain>/, so a wrapper folder would
+      # land as custom_components/meteoswiss_radar/meteoswiss_radar/ and no
+      # install would work. Verified against a working example
+      # (yandex_pogoda.zip) before adopting this.
+      - name: Package the integration
+        run: |
+          set -euo pipefail
+          cd custom_components/meteoswiss_radar
+          # -X drops extra file attributes, keeping the archive reproducible.
+          # __pycache__ can exist by now: the test step above ran pytest.
+          zip -r -X "$GITHUB_WORKSPACE/meteoswiss_radar.zip" . \
+            -x '*__pycache__*' -x '*.pyc'
+
+      - name: Verify the zip layout
+        run: |
+          set -euo pipefail
+          unzip -l meteoswiss_radar.zip
+          # manifest.json at the root is what makes this a valid integration
+          # payload; its absence means the wrapper mistake above.
+          # Normalise a possible './' prefix: Info-ZIP may or may not store
+          # it depending on version, and it is harmless. The mistake worth
+          # failing on is a wrapper directory, not a dot-slash.
+          if ! unzip -Z1 meteoswiss_radar.zip | sed 's|^\./||' | grep -qx 'manifest.json'; then
+            echo "::error::manifest.json is not at the root of the zip."
+            exit 1
+          fi
+          if unzip -Z1 meteoswiss_radar.zip | grep -q '__pycache__'; then
+            echo "::error::__pycache__ leaked into the release asset."
+            exit 1
+          fi
+
+      # The zip is the asset HACS downloads (hacs.json: zip_release +
+      # filename). The repo tree stays the fallback for default-branch
+      # installs, which HACS never serves from a release.
       - name: Create the GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -149,4 +191,5 @@ jobs:
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "${{ steps.title.outputs.title }}" \
             --notes-file release-notes.md \
-            --verify-tag
+            --verify-tag \
+            meteoswiss_radar.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ the two existing tags (`0.7.6`, `0.8.0`) keep their original form.
 
 ## [Unreleased]
 
+### Changed
+
+- Releases now ship a `meteoswiss_radar.zip` asset and `hacs.json` sets
+  `zip_release` (ADR-0008). HACS only increments a release's download counter
+  when it fetches an *asset*, and for an integration it only does that with
+  `zip_release` set — otherwise it walks the repo tree. That is why every
+  release from `0.7.6` to `v0.13.0` reports **0 downloads** despite real
+  installs, and why the README's downloads badge could never move. HACS also
+  installs faster from one artifact than from a tree walk (#185)
+
+
 ### Fixed
 
 - CI: `release.yml` now reads the annotated tag's message through the GitHub

--- a/docs/adr/0008-zip-release-asset.md
+++ b/docs/adr/0008-zip-release-asset.md
@@ -1,0 +1,78 @@
+# ADR-0008: Ship a zip release asset so installs are countable
+
+- **Status:** Accepted
+- **Date:** 2026-08-25
+
+## Context
+
+HACS reported **0 downloads** for this repository across every release from
+`0.7.6` to `v0.13.0`, including installs we know happened. The number is not
+wrong; it is measuring something we never produce.
+
+HACS' "downloads" is GitHub's **release-asset** download counter. It only moves
+when HACS fetches a release asset, and `should_try_releases` in HACS'
+`repositories/base.py` decides that:
+
+```python
+if self.repository_manifest.zip_release:
+    if self.repository_manifest.filename.endswith(".zip"):
+        if self.ref != self.data.default_branch:
+            return True
+if self.ref == self.data.default_branch:
+    return False
+if self.data.category not in ["plugin", "theme"]:
+    return False
+```
+
+An `integration` without `zip_release` never reaches a release asset — HACS
+installs it by walking the repository tree. So the counter is pinned at zero
+however many people install, permanently.
+
+Two comparisons confirmed the mechanism rather than inferring it:
+
+| Repository | hacs.json | Assets | HACS shows |
+| --- | --- | --- | --- |
+| `chriguschneider/weather-station-card` (plugin) | `filename: weather-station-card.js` | 25, each ~177 downloads | three digits |
+| `yandex/pogoda-home-assistant` (integration) | **`zip_release: true`** | `yandex_pogoda.zip` = 5026 | 4765 |
+| this repo | neither | **0 on every release** | 0 |
+
+This has a second cost. The README carries a
+`img.shields.io/github/downloads/.../total` badge reading the same counter, and
+`hacs.json` sets `render_readme: true`. So the HACS store page — the discovery
+surface once the default-store entry lands — displays "0 downloads" beside the
+integration. A visitor reads that as "nobody uses this".
+
+## Decision
+
+Set `zip_release: true` and `filename: meteoswiss_radar.zip` in `hacs.json`,
+and have `release.yml` build and attach that asset.
+
+The archive holds the **contents** of `custom_components/meteoswiss_radar/` at
+its root, not the directory itself. HACS extracts it straight into
+`custom_components/<domain>/`; a wrapper folder would produce
+`custom_components/meteoswiss_radar/meteoswiss_radar/` and no install would
+work. Verified against a working example (`yandex_pogoda.zip`) before adopting.
+
+`release.yml` asserts the layout — `manifest.json` at the root, no
+`__pycache__` — and fails the release rather than publishing a broken asset.
+
+`content_in_root: false` stays: the tree-walk remains the path for
+default-branch installs, which HACS never serves from a release.
+
+## Consequences
+
+- Installs become countable, and the README badge starts telling the truth.
+  This matters beyond vanity: whether anyone uses the integration is the
+  evidence a 1.0 depends on, and it was unobservable before.
+- HACS downloads one artifact instead of walking the tree — faster, and less
+  GitHub API pressure per install.
+- **This supersedes point 4 of ADR-0004's Decision**, which reads *"No release
+  assets are needed: HACS downloads the repo zip for integrations."* That was
+  true of what HACS does by default; it was not true of what makes installs
+  visible. ADR-0004 otherwise stands unchanged.
+- A malformed asset breaks installation for everyone, which the repo tree never
+  could. Hence the layout assertion in CI. Adopting this before the default
+  store entry lands is deliberate: the blast radius is smallest now.
+- The release path gains a build step. This does **not** touch ADR-0002 — the
+  card is still hand-authored and shipped as-is; the zip only packages files
+  that already exist.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,3 +35,4 @@ added test coverage, and prose/style tweaks.
 - [0005 — CodeQL static analysis as a quality gate](0005-codeql-static-analysis.md)
 - [0006 — Scheduled live smoke test against MeteoSwiss API](0006-scheduled-live-smoke-test.md)
 - [0007 — SonarCloud quality gate via CI-based analysis](0007-sonarcloud-quality-gate.md)
+- [0008 — Ship a zip release asset so installs are countable](0008-zip-release-asset.md)

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,7 @@
   "name": "MeteoSwiss Radar",
   "content_in_root": false,
   "render_readme": true,
-  "homeassistant": "2024.7.0"
+  "homeassistant": "2024.7.0",
+  "zip_release": true,
+  "filename": "meteoswiss_radar.zip"
 }

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -135,6 +135,40 @@ def test_hacs_json_is_valid() -> None:
     assert hacs["homeassistant"] == "2024.7.0"
 
 
+def test_zip_release_asset_is_wired_end_to_end() -> None:
+    """The zip must be requested, named, and actually built (ADR-0008).
+
+    HACS only increments a release's download counter when it fetches a
+    release asset, and it only does that when zip_release is set with a
+    .zip filename. Three files have to agree; if any drifts, installs
+    either stop counting or break outright, and nothing else notices.
+    """
+    hacs = json.loads((ROOT / "hacs.json").read_text(encoding="utf-8"))
+    domain = _manifest()["domain"]
+
+    assert hacs.get("zip_release") is True, (
+        "hacs.json must set zip_release, or HACS walks the repo tree and the "
+        "download counter stays at zero forever (ADR-0008)"
+    )
+    expected = f"{domain}.zip"
+    assert hacs.get("filename") == expected, (
+        f"hacs.json filename must be {expected!r} to match the manifest domain"
+    )
+
+    release_workflow = (
+        ROOT / ".github" / "workflows" / "release.yml"
+    ).read_text(encoding="utf-8")
+    assert expected in release_workflow, (
+        f"release.yml must build and attach {expected}; hacs.json points HACS "
+        "at an asset that would not exist"
+    )
+    # The zip holds the *contents* of the integration directory. A wrapper
+    # folder lands as custom_components/<domain>/<domain>/ and nothing loads.
+    assert "cd custom_components/meteoswiss_radar" in release_workflow, (
+        "release.yml must zip from inside the integration directory"
+    )
+
+
 def test_readme_reflects_hacs_default_store() -> None:
     """README must reflect HACS default-store membership (issue #85).
 


### PR DESCRIPTION
## The question this answers

"HACS says 0 downloads, but I installed it myself."

The install happened. The counter cannot move.

## Why

HACS' "downloads" is GitHub's release-**asset** download counter. `should_try_releases` in HACS' [`repositories/base.py`](https://github.com/hacs/integration/blob/main/custom_components/hacs/repositories/base.py) decides whether an asset is ever fetched:

```python
if self.repository_manifest.zip_release:
    if self.repository_manifest.filename.endswith(".zip"):
        if self.ref != self.data.default_branch:
            return True
if self.ref == self.data.default_branch:
    return False
if self.data.category not in ["plugin", "theme"]:
    return False
```

An `integration` without `zip_release` never reaches that branch — HACS installs it by walking the repo tree. So the counter is pinned at zero however many people install, forever.

Confirmed against live examples rather than inferred:

| Repository | hacs.json | Assets | HACS shows |
| --- | --- | --- | --- |
| `chriguschneider/weather-station-card` (plugin) | `filename: weather-station-card.js` | 25, ~177 downloads each | three digits |
| `yandex/pogoda-home-assistant` (integration) | **`zip_release: true`** | `yandex_pogoda.zip` = 5026 | 4765 |
| **this repo** | neither | **0 on every release** | **0** |

## The second cost

The README badge is `img.shields.io/github/downloads/.../total` — the same counter — and `hacs.json` sets `render_readme: true`. So the HACS store page, the discovery surface once #10323 lands, shows **"0 downloads"** next to the integration. A visitor reads that as "nobody uses this". It has also been visible from the forum post since yesterday.

## What changes

`hacs.json` gets `zip_release: true` + `filename: meteoswiss_radar.zip`; `release.yml` builds and attaches it.

**Layout is the part that can break installs.** The zip holds the *contents* of `custom_components/meteoswiss_radar/` at its root, not the directory. HACS extracts straight into `custom_components/<domain>/`, so a wrapper would land as `custom_components/meteoswiss_radar/meteoswiss_radar/` and nothing would load. I opened `yandex_pogoda.zip` to check the shape before copying it:

```
translations/  __init__.py  config_flow.py  const.py  manifest.json  sensor.py  ...
```

Ours, simulated locally from the same file set:

```
entries: 16   manifest.json at root: True   __pycache__ leaked: False   166 KiB
top level: __init__.py  brand  config_flow.py  const.py  frontend  manifest.json  strings.json  translations
```

`release.yml` asserts both invariants and fails the release rather than publishing a broken asset. The `manifest.json` check tolerates a `./` prefix — Info-ZIP is inconsistent about storing it, and that is not the mistake worth failing on.

`content_in_root: false` stays: the tree walk is still how default-branch installs work, which HACS never serves from a release.

## Drift guard

`test_zip_release_asset_is_wired_end_to_end` pins the three files that must agree — the manifest `domain`, `hacs.json`'s `filename`, and the workflow that builds it. If they drift, installs either stop counting or break outright, and nothing else in CI would notice.

## ADR-0008

Required by `docs/adr/README.md` — this deviates from an accepted ADR. Point 4 of ADR-0004's Decision reads *"No release assets are needed: HACS downloads the repo zip for integrations."* True of what HACS does by default; not true of what makes installs visible. ADR-0004 otherwise stands.

Explicitly **not** an ADR-0002 concern: the card is still hand-authored and shipped as-is. The zip only packages files that already exist — no bundler, no transform.

## Risk, stated plainly

A malformed asset breaks installation for **everyone**, which the repo tree never could. That is why the layout assertion exists, and why doing this now rather than after #10323 is deliberate: the blast radius is smallest while nobody is installing.

The packaging steps cannot be exercised without pushing a tag. They run for the first time at v0.14.0, and I would rather cut that release and verify the asset than let the first run be a surprise.

## How verified

```
python -m pytest -q                            # 160 passed (2 new)
python -m ruff check custom_components tests   # All checks passed
```
Zip layout simulated locally; `release.yml` parses and the verify step is shell-syntax clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
