### PR TITLE
chore(release): v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ the two existing tags (`0.7.6`, `0.8.0`) keep their original form.
 
 ## [Unreleased]
 
+## [v0.14.0] — 2026-08-25
+
 ### Changed
 
 - Releases now ship a `meteoswiss_radar.zip` asset and `hacs.json` sets
@@ -17,7 +19,6 @@ the two existing tags (`0.7.6`, `0.8.0`) keep their original form.
   release from `0.7.6` to `v0.13.0` reports **0 downloads** despite real
   installs, and why the README's downloads badge could never move. HACS also
   installs faster from one artifact than from a tree walk (#185)
-
 
 ### Fixed
 
@@ -229,7 +230,8 @@ and test improvements from the 2026-08-22 architecture review.
   for the card decoder (#16); full proxy allowlist, cache-header, and
   lifecycle coverage (#17)
 
-[Unreleased]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.14.0...HEAD
+[v0.14.0]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.13.0...v0.14.0
 [v0.13.0]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.12.0...v0.13.0
 [v0.12.0]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.11.0...v0.12.0
 [v0.11.0]: https://github.com/chriguschneider/hass-meteoswiss-radar/compare/v0.10.0...v0.11.0

--- a/custom_components/meteoswiss_radar/const.py
+++ b/custom_components/meteoswiss_radar/const.py
@@ -3,7 +3,7 @@
 DOMAIN = "meteoswiss_radar"
 
 # Keep in sync with manifest.json and the card's CARD_VERSION.
-VERSION = "0.13.0"
+VERSION = "0.14.0"
 
 UPSTREAM_BASE = "https://www.meteoschweiz.admin.ch"
 

--- a/custom_components/meteoswiss_radar/frontend/meteoswiss-radar-card.js
+++ b/custom_components/meteoswiss_radar/frontend/meteoswiss-radar-card.js
@@ -4,7 +4,7 @@
  * authenticated proxy. Frame format: see FORMAT.md in the repository root.
  */
 
-const CARD_VERSION = "0.13.0";
+const CARD_VERSION = "0.14.0";
 const FRONTEND_BASE = "/meteoswiss_radar/frontend";
 const PROXY_BASE = "meteoswiss_radar/proxy"; // hass.callApi() prepends /api/
 

--- a/custom_components/meteoswiss_radar/manifest.json
+++ b/custom_components/meteoswiss_radar/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/chriguschneider/hass-meteoswiss-radar/issues",
   "requirements": [],
   "single_config_entry": true,
-  "version": "0.13.0"
+  "version": "0.14.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hass-meteoswiss-radar-card",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hass-meteoswiss-radar-card",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "devDependencies": {
         "@vitest/coverage-v8": "^3.2.7",
         "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hass-meteoswiss-radar-card",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "type": "module",
   "description": "Tests and syntax checks for the MeteoSwiss Radar Lovelace card.",


### PR DESCRIPTION
## Summary

The release that makes installs countable — and the first exercise of two things added today that could only ever be tested by cutting a release.

**First run of the packaging path** (ADR-0008, #185): `release.yml` builds `meteoswiss_radar.zip` from the contents of `custom_components/meteoswiss_radar/`, asserts `manifest.json` sits at the root and no `__pycache__` leaked, then attaches it. If the layout is wrong the release fails instead of publishing a broken asset.

**First run of the API-based release title** (#184): v0.13.0 shipped titled bare because `actions/checkout` overwrites the triggering tag with the resolved commit, making the annotated message unreachable locally.

## Why existing installs are safe

`async_get_hacs_json` fetches `hacs.json` at `ref or self.version_to_download()` — the version being installed, not the default branch. So anyone installing v0.13.0 reads v0.13.0's `hacs.json`, which has no `zip_release`, and still gets the tree walk. Only v0.14.0 onward uses the asset.

## How verified

```
python -m pytest -q     # 160 passed
npm test                # 211 passed
```

The zip layout was simulated locally (16 entries, `manifest.json` at root, no `__pycache__`, 166 KiB). The real proof is the release this produces — I will check the published asset before calling it done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
