### PR TITLE
fix(ci): Claude workflows check out without persisted credentials

### DIFF
--- a/.github/workflows/claude-autopilot.yml
+++ b/.github/workflows/claude-autopilot.yml
@@ -39,6 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       # Gate: never start a second issue while an agent PR is still open.

--- a/.github/workflows/claude-labeled.yml
+++ b/.github/workflows/claude-labeled.yml
@@ -31,6 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Pick model

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -35,6 +35,8 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Pick model from issue labels
         id: model

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -37,6 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Review, fix (bounded), decide


### PR DESCRIPTION
Same fix as chriguschneider/hass-meteoswiss-weather#27: actions/checkout v6+ stores GITHUB_TOKEN in an includeIf credentials file that claude-code-action does not clear, so agent pushes go out as github-actions[bot] and their CI runs wait for approval. persist-credentials: false on the Claude workflows' checkout steps; harmless on v4, required once dependabot bumps checkout.