### PR TITLE
fix(ci): review runs on ready_for_review, mentions get 60 turns

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -50,4 +50,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The action reads the @claude comment as the task automatically.
-          claude_args: "--model ${{ steps.model.outputs.model }} --max-turns 20 --dangerously-skip-permissions"
+          # 60 turns, not 20: a mention that asks for an actual change
+          # (edit, run, push) hits 20 while still gathering context.
+          claude_args: "--model ${{ steps.model.outputs.model }} --max-turns 60 --dangerously-skip-permissions"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -20,11 +20,14 @@ on:
 
 jobs:
   review:
-    # Only agent branches, and skip the reviewer's own bot pushes.
+    # Only agent branches. `draft == true` alone would never match a
+    # ready_for_review event (the PR is no longer a draft by then), so
+    # an agent marking its own PR ready would skip review entirely.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (startsWith(github.event.pull_request.head.ref, 'claude/') &&
-       github.event.pull_request.draft == true)
+       (github.event.action == 'ready_for_review' ||
+        github.event.pull_request.draft == true))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Two papercuts found while finishing hass-meteoswiss-weather#33.

**Review gate.** `claude-review.yml` triggers on `[opened, ready_for_review]` but guards on `draft == true`. That is false by definition once a PR is marked ready, so the `ready_for_review` path never passed the guard: an agent that marks its own draft ready skips the independent review. #33 had to be reviewed via a manual `workflow_dispatch`.

**Mention budget.** `--max-turns 20` is enough for an answer but not for a mention that asks for an actual change; a real request hit the limit with its todo list half done.